### PR TITLE
support more multi-controlled gates in converters

### DIFF
--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -309,6 +309,8 @@ class CircuitBuilder:
                 params = [param_to_tk(p) for p in i.base_gate.params]
                 n_base_qubits = i.base_gate.num_qubits
                 sub_circ = Circuit(n_base_qubits)
+                # use base gate name for the CircBox (shows in renderer)
+                sub_circ.name = i.base_gate.name.capitalize()
                 sub_circ.add_gate(base_tket_gate, params, list(range(n_base_qubits)))
                 c_box = CircBox(sub_circ)
                 q_ctrl_box = QControlBox(c_box, i.num_ctrl_qubits)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -66,7 +66,7 @@ from qiskit.circuit import (
     Reset,
 )
 from qiskit.circuit.library import CRYGate  # type: ignore
-from qiskit.circuit.library import MCMT, PauliEvolutionGate, RYGate
+from qiskit.circuit.library import PauliEvolutionGate, RYGate
 from qiskit.extensions.unitary import UnitaryGate  # type: ignore
 
 if TYPE_CHECKING:

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -18,19 +18,16 @@ from typing import List, Set, Union
 
 import numpy as np
 import pytest
-import qiskit.circuit.library.standard_gates as qiskit_gates
+import qiskit.circuit.library.standard_gates as qiskit_gates  # type :ignore
+from pytket.circuit import CircBox  # type: ignore
 from pytket.circuit import Circuit  # type: ignore
-from pytket.circuit import (
-    Bit,
-    CircBox,
-    CustomGateDef,
-    OpType,
-    Qubit,
-    Unitary2qBox,
-    reg_eq,
-)
+from pytket.circuit import CustomGateDef  # type: ignore
+from pytket.circuit import OpType  # type: ignore
+from pytket.circuit import Qubit  # type: ignore
+from pytket.circuit import Unitary2qBox  # type: ignore
+from pytket.circuit import Bit, reg_eq
 from pytket.passes import DecomposeBoxes  # type: ignore
-from pytket.passes import FullPeepholeOptimise, RebaseTket, SequencePass
+from pytket.passes import FullPeepholeOptimise, RebaseTket, SequencePass  # type: ignore
 from pytket.utils.results import (
     compare_statevectors,
     compare_unitaries,
@@ -749,3 +746,23 @@ def test_multicontrolled_gate_conversion() -> None:
     tcirc = qiskit_to_tk(my_new_qc)
     unitary_after = tcirc.get_unitary()
     assert compare_unitaries(unitary_before, unitary_after)
+
+
+def test_qcontrolbox_conversion() -> None:
+    qr = QuantumRegister(3)
+    qc = QuantumCircuit(qr)
+    c2h_gate = qiskit_gates.HGate().control(2)
+    qc.append(c2h_gate, qr)
+    c = qiskit_to_tk(qc)
+    assert c.n_gates == 1
+    assert c.n_gates_of_type(OpType.QControlBox) == 1
+    c3rx_gate = qiskit_gates.RXGate(0.7).control(3)
+    c3rz_gate = qiskit_gates.RZGate(pi / 4).control(3)
+    c2rzz_gate = qiskit_gates.RZZGate(pi / 3).control(2)
+    qc2 = QuantumCircuit(4)
+    qc2.append(c3rz_gate, [0, 1, 3, 2])
+    qc2.append(c3rx_gate, [0, 1, 2, 3])
+    qc2.append(c2rzz_gate, [0, 1, 2, 3])
+    tkc2 = qiskit_to_tk(qc2)
+    assert tkc2.n_gates == 3
+    assert tkc2.n_gates_of_type(OpType.QControlBox) == 3


### PR DESCRIPTION
I'm adding support for general multi-controlled gates in the qiskit converters.

Note that the diff here is a bit inflated by my VScode plugin reordering the imports (forgot to disable this) hopefully it doesn't upset mypy/pylint. Let me know if I should make a fresh PR.

**Changes**
1.  Fixed handling of CnRy gates. These used to be supported but after  https://github.com/CQCL/pytket-qiskit/pull/10 these were decomposed by the rebase prior to conversion. Adding the CnRy gate to the target gateset should take care of this.
2. Added support for CnY and CnZ gates. I previously thought this would be annoying to add https://github.com/CQCL/pytket-qiskit/issues/11 - turns out its easy.
3. Support other controlled gates using `QControlBox` https://github.com/CQCL/pytket-qiskit/issues/28

Also...
4. (A suggestion) - We frequently use conditions like ``if type(i) == ControlledGate`` rather a lot. Shouldn't we be using ``if isinstance(i, ControlledGate)`` ? https://switowski.com/blog/type-vs-isinstance/