### PR TITLE
Feature/convert more controlled gates

### DIFF
--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -53,7 +53,7 @@ from qiskit.circuit import (
     ParameterExpression,
     Reset,
 )
-from qiskit.circuit.library import CRYGate, RYGate, MCMT, PauliEvolutionGate  # type: ignore
+from qiskit.circuit.library import CRYGate, RYGate, PauliEvolutionGate  # type: ignore
 
 from qiskit.extensions.unitary import UnitaryGate  # type: ignore
 from pytket.circuit import (  # type: ignore

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -31,6 +31,7 @@ from qiskit.opflow.primitive_ops import PauliSumOp  # type: ignore
 from qiskit.quantum_info import Pauli  # type: ignore
 from qiskit.transpiler import PassManager  # type: ignore
 from qiskit.circuit.library import RYGate, MCMT  # type: ignore
+import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore
 from qiskit.circuit import Parameter  # type: ignore
 from pytket.circuit import (  # type: ignore
     Circuit,

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -750,3 +750,23 @@ def test_multicontrolled_gate_conversion() -> None:
     tcirc = qiskit_to_tk(my_new_qc)
     unitary_after = tcirc.get_unitary()
     assert compare_unitaries(unitary_before, unitary_after)
+
+
+def test_qcontrolbox_conversion() -> None:
+    qr = QuantumRegister(3)
+    qc = QuantumCircuit(qr)
+    c2h_gate = qiskit_gates.HGate().control(2)
+    qc.append(c2h_gate, qr)
+    c = qiskit_to_tk(qc)
+    assert c.n_gates == 1
+    assert c.n_gates_of_type(OpType.QControlBox) == 1
+    c3rx_gate = qiskit_gates.RXGate(0.7).control(3)
+    c3rz_gate = qiskit_gates.RZGate(pi / 4).control(3)
+    c2rzz_gate = qiskit_gates.RZZGate(pi / 3).control(2)
+    qc2 = QuantumCircuit(4)
+    qc2.append(c3rz_gate, [0, 1, 3, 2])
+    qc2.append(c3rx_gate, [0, 1, 2, 3])
+    qc2.append(c2rzz_gate, [0, 1, 2, 3])
+    tkc2 = qiskit_to_tk(qc2)
+    assert tkc2.n_gates == 3
+    assert tkc2.n_gates_of_type(OpType.QControlBox) == 3


### PR DESCRIPTION
Redo of #49 avoiding formatting issues.

I'm adding support for general multi-controlled gates in the qiskit converters.

Note that the diff here is a bit inflated by my VScode plugin reordering the imports (forgot to disable this) hopefully it doesn't upset mypy/pylint. Let me know if I should make a fresh PR.

Changes

Fixed handling of CnRy gates. These used to be supported but after https://github.com/CQCL/pytket-qiskit/pull/10 these were decomposed by the rebase prior to conversion. Adding the CnRy gate to the target gateset should take care of this.
Added support for CnY and CnZ gates. I previously thought this would be annoying to add https://github.com/CQCL/pytket-qiskit/issues/11 - turns out its easy.
Support other controlled gates using QControlBox https://github.com/CQCL/pytket-qiskit/issues/28
Also...
4. (A suggestion) - We frequently use conditions like if type(i) == ControlledGate rather a lot. Shouldn't we be using if isinstance(i, ControlledGate) ? https://switowski.com/blog/type-vs-isinstance/