### PR TITLE
Fix order of Pauli terms

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Update qiskit version to 0.41.
+* Fix order of Pauli terms when converting from ``QubitPauliOperator``.
 
 0.35.0 (February 2023)
 ----------------------

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -696,7 +696,9 @@ def _qubitpauliop_to_sparsepauliop(
     for term, coeff in operator._dict.items():
         termmap = term.map
         strings.append(
-            "".join(termmap.get(Qubit(i), Pauli.I).name for i in range(n_qubits))
+            "".join(
+                termmap.get(Qubit(i), Pauli.I).name for i in reversed(range(n_qubits))
+            )
         )
         coeffs.append(coeff)
 


### PR DESCRIPTION
Bug reported by Iakov, who has also tested the fix. Problem is difference of endianness convention between pytket and qiskit.