### PR TITLE
Bugfix/aer backend info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 dist
 *.pyc
 .vscode
+.idea
 .venv
 .mypy_cache
 .hypothesis

--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.36.0"
+__extension_version__ = "0.37.0"
 __extension_name__ = "pytket-qiskit"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+"unreleased" 0.37.0 (March 2023)
+----------------------
+
+* Fix faulty information in ``AerBackend().backend_info``
+
 0.36.0 (February 2023)
 ----------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 ~~~~~~~~~
 
-"unreleased" 0.37.0 (March 2023)
-----------------------
+0.37.0 (unreleased)
+-------------------
 
 * Fix faulty information in ``AerBackend().backend_info``
 

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -112,11 +112,11 @@ class _AerBaseBackend(Backend):
                 f"Gate set {self._gate_set} missing at least one of {_required_gates}"
             )
         self._backend_info = BackendInfo(
-            type(self).__name__,
-            backend_name,
-            __extension_version__,
-            Architecture([]),
-            self._gate_set,
+            name=type(self).__name__,
+            device_name=backend_name,
+            version=__extension_version__,
+            architecture=Architecture([]),
+            gate_set=self._gate_set,
             supports_midcircuit_measurement=True,  # is this correct?
             misc={"characterisation": None},
         )
@@ -374,6 +374,7 @@ class AerBackend(_AerBaseBackend):
         :type simulation_method: str
         """
         super().__init__("aer_simulator")
+        self._backend_info.supports_fast_feedforward = True
 
         if not noise_model or all(
             value == [] for value in noise_model.to_dict().values()

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -83,9 +83,6 @@ def _default_q_index(q: Qubit) -> int:
     return int(q.index[0])
 
 
-_required_gates: Set[OpType] = {OpType.CX, OpType.U1, OpType.U2, OpType.U3}
-
-
 def _tket_gate_set_from_qiskit_backend(
     qiskit_backend: "QiskitAerBackend",
 ) -> Set[OpType]:
@@ -96,10 +93,6 @@ def _tket_gate_set_from_qiskit_backend(
     }
     # special case mapping TK1 to U
     gates.add(OpType.TK1)
-    if not gates >= _required_gates:
-        raise NotImplementedError(
-            f"Gate set {gates} missing at least one of {_required_gates}"
-        )
     return gates
 
 

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -14,7 +14,7 @@
 
 import itertools
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from logging import warning
 from typing import (
     Dict,

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -426,7 +426,12 @@ class AerBackend(_AerBaseBackend):
     _memory = True
 
     _qiskit_backend_name = "aer_simulator"
-    _allowed_special_gates = {OpType.Measure, OpType.Barrier, OpType.Reset, OpType.RangePredicate}
+    _allowed_special_gates = {
+        OpType.Measure,
+        OpType.Barrier,
+        OpType.Reset,
+        OpType.RangePredicate,
+    }
 
     def __init__(
         self,
@@ -447,7 +452,9 @@ class AerBackend(_AerBaseBackend):
             self._qiskit_backend_name
         )
         self._qiskit_backend.set_options(method=simulation_method)
-        gate_set = _tket_gate_set_from_qiskit_backend(self._qiskit_backend).union(self._allowed_special_gates)
+        gate_set = _tket_gate_set_from_qiskit_backend(self._qiskit_backend).union(
+            self._allowed_special_gates
+        )
         self._noise_model = _map_trivial_noise_model_to_none(noise_model)
         characterisation = _get_characterisation_of_noise_model(
             self._noise_model, gate_set

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -32,6 +32,11 @@ from typing import (
 )
 
 import numpy as np
+from qiskit.providers.aer.noise import NoiseModel  # type: ignore
+from qiskit.quantum_info.operators import Pauli as qk_Pauli  # type: ignore
+from qiskit.quantum_info.operators.symplectic.sparse_pauli_op import SparsePauliOp  # type: ignore
+from qiskit_aer import Aer  # type: ignore
+from qiskit_aer.library import save_expectation_value  # type: ignore # pylint: disable=unused-import
 from pytket.architecture import Architecture  # type: ignore
 from pytket.backends import Backend, CircuitNotRunError, CircuitStatus, ResultHandle
 from pytket.backends.backendinfo import BackendInfo
@@ -61,11 +66,6 @@ from pytket.predicates import (  # type: ignore
 )
 from pytket.utils.operators import QubitPauliOperator
 from pytket.utils.results import KwargTypes
-from qiskit.providers.aer.noise import NoiseModel  # type: ignore
-from qiskit.quantum_info.operators import Pauli as qk_Pauli  # type: ignore
-from qiskit.quantum_info.operators.symplectic.sparse_pauli_op import SparsePauliOp  # type: ignore
-from qiskit_aer import Aer  # type: ignore
-from qiskit_aer.library import save_expectation_value  # type: ignore # pylint: disable=unused-import
 
 from .ibm_utils import _STATUS_MAP, _batch_circuits
 from .._metadata import __extension_version__

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -72,7 +72,6 @@ from .._metadata import __extension_version__
 from ..qiskit_convert import (
     tk_to_qiskit,
     _gate_str_2_optype,
-    _tk_gate_set,
     get_avg_characterisation,
 )
 from ..result_convert import qiskit_result_to_backendresult

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -207,10 +207,7 @@ def _tk_gate_set(backend: "QiskitBackend") -> Set[OpType]:
             _gate_str_2_optype[gate_str]
             for gate_str in config.basis_gates
             if gate_str in _gate_str_2_optype
-        }.union({OpType.Measure, OpType.Reset, OpType.Barrier, OpType.RangePredicate})
-        if "unitary" in config.basis_gates:
-            gate_set.add(OpType.Unitary1qBox)
-            gate_set.add(OpType.Unitary3qBox)
+        }.union({OpType.Measure, OpType.Reset, OpType.Barrier})
         return gate_set
 
     else:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -203,11 +203,16 @@ def _tk_gate_set(backend: "QiskitBackend") -> Set[OpType]:
     """Set of tket gate types supported by the qiskit backend"""
     config = backend.configuration()
     if config.simulator:
-        return {
+        gate_set = {
             _gate_str_2_optype[gate_str]
             for gate_str in config.basis_gates
             if gate_str in _gate_str_2_optype
-        }.union({OpType.Measure, OpType.Reset, OpType.Barrier})
+        }.union({OpType.Measure, OpType.Reset, OpType.Barrier, OpType.RangePredicate})
+        if "unitary" in config.basis_gates:
+            gate_set.add(OpType.Unitary1qBox)
+            gate_set.add(OpType.Unitary3qBox)
+        return gate_set
+
     else:
         return {
             _gate_str_2_optype[gate_str]

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "qiskit ~= 0.41.0",
         "qiskit-ibm-runtime ~= 0.8.0",
         "qiskit-aer ~= 0.11.2",
-        "numpy"
+        "numpy",
     ],
     classifiers=[
         "Environment :: Console",

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "qiskit ~= 0.41.0",
         "qiskit-ibm-runtime ~= 0.8.0",
         "qiskit-aer ~= 0.11.2",
+        "numpy"
     ],
     classifiers=[
         "Environment :: Console",

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -908,11 +908,11 @@ def test_simulation_method() -> None:
         counts = b.run_circuit(clifford_T_circ, n_shots=4).get_counts()
         assert sum(val for _, val in counts.items()) == 4
 
-    with pytest.raises(AttributeError) as warninfo:
+    with pytest.raises(CircuitNotValidError) as warninfo:
         # check for the error thrown when non-clifford circuit used with
         # stabilizer backend
         stabilizer_backend.run_circuit(clifford_T_circ, n_shots=4).get_counts()
-        assert "Attribute header is not defined" in str(warninfo.value)
+        assert "Circuit with index 0 in submitted does not satisfy GateSetPredicate" in str(warninfo.value)
 
 
 def test_aer_expanded_gates() -> None:

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -21,7 +21,6 @@ from hypothesis import given, strategies
 import numpy as np
 
 import pytest
-from pytket import Bit
 
 from qiskit import IBMQ  # type: ignore
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -21,6 +21,7 @@ from hypothesis import given, strategies
 import numpy as np
 
 import pytest
+from pytket import Bit
 
 from qiskit import IBMQ  # type: ignore
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -247,21 +247,19 @@ def test_process_characterisation_incomplete_noise_model() -> None:
 
     arch = back.backend_info.architecture
     nodes = arch.nodes
-    assert set(arch.coupling) == set(
-        [
-            (nodes[0], nodes[1]),
-            (nodes[0], nodes[2]),
-            (nodes[0], nodes[3]),
-            (nodes[1], nodes[2]),
-            (nodes[1], nodes[3]),
-            (nodes[2], nodes[0]),
-            (nodes[2], nodes[1]),
-            (nodes[2], nodes[3]),
-            (nodes[3], nodes[0]),
-            (nodes[3], nodes[1]),
-            (nodes[3], nodes[2]),
-        ]
-    )
+    assert set(arch.coupling) == {
+        (nodes[0], nodes[1]),
+        (nodes[0], nodes[2]),
+        (nodes[0], nodes[3]),
+        (nodes[1], nodes[2]),
+        (nodes[1], nodes[3]),
+        (nodes[2], nodes[0]),
+        (nodes[2], nodes[1]),
+        (nodes[2], nodes[3]),
+        (nodes[3], nodes[0]),
+        (nodes[3], nodes[1]),
+        (nodes[3], nodes[2]),
+    }
 
 
 def test_circuit_compilation_complete_noise_model() -> None:
@@ -912,7 +910,10 @@ def test_simulation_method() -> None:
         # check for the error thrown when non-clifford circuit used with
         # stabilizer backend
         stabilizer_backend.run_circuit(clifford_T_circ, n_shots=4).get_counts()
-        assert "Circuit with index 0 in submitted does not satisfy GateSetPredicate" in str(warninfo.value)
+        assert (
+            "Circuit with index 0 in submitted does not satisfy GateSetPredicate"
+            in str(warninfo.value)
+        )
 
 
 def test_aer_expanded_gates() -> None:


### PR DESCRIPTION
- Refactored `aer.py` to hopefully make it clearer what settings are being used for `AerBackend`, `AerStateBackend`, and  `AerUnitaryBackend`.

- set `supports_fast_feedforward=True` for  `AerBackend`, Resolves #81
- use same gate set for backend_info.gate_set, gate set predicate, and rebase pass, Resolves #75 