### PR TITLE
handle state prep boxes in qiskit converters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 -------------------
 
 * Fix to the `tk_to_qiskit` converter to prevent cancellation of redundant gates when converting to qiskit.
-* Handle qiskit state initialisation circuits with :py:class:`StatePreparationBox` in the circuit converters.
+* Handle qiskit circuits with :py:class:`Initialize` and :py:class:`StatePreparation` instructions in the :py:meth:`qiskit_to_tk` and :py:meth:`tk_to_qiskit` converters.
 
 0.39.0 (May 2023)
 -----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,8 @@
 Changelog
 ~~~~~~~~~
+0.40.0 (unreleased)
+-------------------
+* Handle qiskit state initialisation circuits with :py:class:`StatePreparationBox` in the circuit converters.
 
 0.39.0 (May 2023)
 -----------------

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -57,6 +57,7 @@ from qiskit.circuit.library import CRYGate, RYGate, PauliEvolutionGate, StatePre
 
 from qiskit.extensions.unitary import UnitaryGate  # type: ignore
 from qiskit.extensions import Initialize  # type: ignore
+from qiskit.quantum_info import Statevector 
 from pytket.circuit import (  # type: ignore
     CircBox,
     Circuit,
@@ -258,7 +259,7 @@ def _string_to_circuit(
         for qubit in circ.qubits:
             circ.add_gate(OpType.Reset, [qubit])
 
-    for count, char in enumerate(circuit_string):
+    for count, char in enumerate(reversed(circuit_string)):
         if char == "0":
             pass
         if char in ("1", "-"):
@@ -376,7 +377,8 @@ class CircuitBuilder:
                         pytket_state_prep_box = StatePreparationBox(
                             amplitude_list, with_initial_reset=False
                         )
-                    self.tkc.add_gate(pytket_state_prep_box, qubits)
+                    reversed_qubits = list(reversed(qubits))
+                    self.tkc.add_gate(pytket_state_prep_box, reversed_qubits)
 
                 elif isinstance(instr.params[0], complex) and len(instr.params) == 1:
                     # convert int to a binary string and apply X for |1>

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -53,10 +53,10 @@ from qiskit.circuit import (
     ParameterExpression,
     Reset,
 )
-from qiskit.circuit.library import CRYGate, RYGate, PauliEvolutionGate  # type: ignore
+from qiskit.circuit.library import CRYGate, RYGate, PauliEvolutionGate, StatePreparation  # type: ignore
 
 from qiskit.extensions.unitary import UnitaryGate  # type: ignore
-from qiskit.extensions import Initialize, StatePreparation  # type: ignore
+from qiskit.extensions import Initialize  # type: ignore
 from pytket.circuit import (  # type: ignore
     CircBox,
     Circuit,
@@ -151,6 +151,7 @@ _qiskit_gates_other = {
     Reset: OpType.Reset,
     UnitaryGate: OpType.Unitary2qBox,
     Initialize: OpType.StatePreparationBox,
+    StatePreparation: OpType.StatePreparationBox
 }
 
 _known_qiskit_gate = {**_qiskit_gates_1q, **_qiskit_gates_2q, **_qiskit_gates_other}
@@ -252,6 +253,7 @@ def _string_to_circuit(
 
     circ = Circuit(n_qubits)
     # Check if Instruction is Initialize or Statepreparation
+    # If Initialize, add resets
     if isinstance(qiskit_instruction, Initialize):
         for qubit in circ.qubits:
             circ.add_gate(OpType.Reset, [qubit])

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -367,9 +367,14 @@ class CircuitBuilder:
 
                 elif isinstance(instr.params, list) and len(instr.params) != 1:
                     amplitude_list = instr.params
-                    pytket_state_prep_box = StatePreparationBox(
-                        amplitude_list, qiskit_instruction=instr
-                    )
+                    if isinstance(instr, Initialize):
+                        pytket_state_prep_box = StatePreparationBox(
+                            amplitude_list, with_initial_reset=True
+                        )
+                    else:
+                        pytket_state_prep_box = StatePreparationBox(
+                            amplitude_list, with_initial_reset=False
+                        )
                     self.tkc.add_gate(pytket_state_prep_box, qubits)
 
                 elif isinstance(instr.params[0], complex) and len(instr.params) == 1:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -359,6 +359,7 @@ class CircuitBuilder:
                 elif isinstance(instr.params, int):
                     bitstring = bin(instr.params[0])[2:]
                     for count, bit in enumerate(bitstring):
+                        self.tkc.add_gate(OpType.Reset, [count])
                         if bit == "1":
                             self.tkc.X(count)
                         

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -150,6 +150,7 @@ _qiskit_gates_other = {
     Measure: OpType.Measure,
     Reset: OpType.Reset,
     UnitaryGate: OpType.Unitary2qBox,
+    Initialize: OpType.StatePreparationBox
 }
 
 _known_qiskit_gate = {**_qiskit_gates_1q, **_qiskit_gates_2q, **_qiskit_gates_other}
@@ -485,6 +486,12 @@ def append_tk_command_to_qiskit(
         # Note reversal of qubits, to account for endianness (pytket unitaries are
         # ILO-BE == DLO-LE; qiskit unitaries are ILO-LE == DLO-BE).
         return qcirc.append(g, qargs=list(reversed(qargs)))
+    if optype == OpType.StatePreparationBox:
+        stateprep_op = Op.create(optype)
+        statevector_array = stateprep_op.get_statevector()
+        initializer = Initialize(statevector_array)
+        return qcirc.append(initializer, qargs=list(reversed(qargs)))
+    
     if optype == OpType.Barrier:
         if any(q.type == UnitType.bit for q in args):
             raise NotImplementedError(

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -357,7 +357,7 @@ class CircuitBuilder:
                 self.tkc.add_qcontrolbox(q_ctrl_box, qubits)
 
             elif isinstance(instr, (Initialize, StatePreparation)):
-                # We need to check how Initialize is constructed. There are several ways.
+                # Check how Initialize or StatePrep is constructed
                 if isinstance(instr.params[0], str):
                     # Parse string to get the right single qubit gates
                     circuit_string = "".join(instr.params)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -330,7 +330,7 @@ class CircuitBuilder:
                 self.tkc.add_qcontrolbox(q_ctrl_box, qubits)
 
             elif isinstance(instr, Initialize):
-                # Check that the Initialize object is constructed with a list:
+                # A qiskit Initialize object can be constructed using different data types:
                 # https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.initialize.html
                 if isinstance(instr.params, list):
                     amplitude_list = instr.params
@@ -341,6 +341,7 @@ class CircuitBuilder:
                     statevector = Statevector.from_label(instr.params)
                     pytket_state_prep_box = StatePreparationBox(statevector.data)
                     self.tkc.add_gate(pytket_state_prep_box, qubits)
+
                 elif isinstance(instr.params, int):
                     bitstring = bin(instr.params[0])[2:]
                     for count, bit in enumerate(bitstring):

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -380,8 +380,8 @@ class CircuitBuilder:
 
                 elif isinstance(instr.params[0], complex) and len(instr.params) == 1:
                     # convert int to a binary string and apply X for |1>
-                    instr.params[0] = int(instr.params[0].real)
-                    bit_string = bin(instr.params[0])[2:]
+                    integer_parameter = int(instr.params[0].real)
+                    bit_string = bin(integer_parameter)[2:]
                     circuit = _string_to_circuit(
                         bit_string, instr.num_qubits, qiskit_instruction=instr
                     )

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -356,9 +356,8 @@ class CircuitBuilder:
                 q_ctrl_box = QControlBox(c_box, instr.num_ctrl_qubits)
                 self.tkc.add_qcontrolbox(q_ctrl_box, qubits)
 
-            elif isinstance(instr, Initialize) or isinstance(instr, StatePreparation):
+            elif isinstance(instr, (Initialize, StatePreparation)):
                 # We need to check how Initialize is constructed. There are several ways.
-                # https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.initialize.html
                 if isinstance(instr.params[0], str):
                     # Parse string to get the right single qubit gates
                     circuit_string = "".join(instr.params)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -71,6 +71,7 @@ from pytket.circuit import (  # type: ignore
     QControlBox,
     StatePreparationBox,
 )
+from qiskit.quantum_info import Statevector
 from pytket._tket.circuit import _TEMP_BIT_NAME  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore
 from pytket.architecture import Architecture, FullyConnected  # type: ignore
@@ -335,6 +336,16 @@ class CircuitBuilder:
                     amplitude_list = instr.params
                     pytket_state_prep_box = StatePreparationBox(amplitude_list)
                     self.tkc.add_gate(pytket_state_prep_box, qubits)
+
+                elif isinstance(instr.params, str):
+                    statevector = Statevector.from_label(instr.params)
+                    pytket_state_prep_box = StatePreparationBox(statevector.data)
+                    self.tkc.add_gate(pytket_state_prep_box, qubits)
+                elif isinstance(instr.params, int):
+                    bitstring = bin(instr.params[0])[2:]
+                    for count, bit in enumerate(bitstring):
+                        if bit == "1":
+                            self.tkc.X(count)
 
             elif type(instr) == PauliEvolutionGate:
                 qpo = _qpo_from_peg(instr, qubits)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -56,6 +56,7 @@ from qiskit.circuit import (
 from qiskit.circuit.library import CRYGate, RYGate, PauliEvolutionGate  # type: ignore
 
 from qiskit.extensions.unitary import UnitaryGate  # type: ignore
+from qiskit.extensions import Initialize  # type: ignore
 from pytket.circuit import (  # type: ignore
     CircBox,
     Circuit,
@@ -68,6 +69,7 @@ from pytket.circuit import (  # type: ignore
     Bit,
     Qubit,
     QControlBox,
+    StatePreparationBox,
 )
 from pytket._tket.circuit import _TEMP_BIT_NAME  # type: ignore
 from pytket.pauli import Pauli, QubitPauliString  # type: ignore
@@ -300,6 +302,8 @@ class CircuitBuilder:
                         )
             elif type(instr) == PauliEvolutionGate:
                 pass  # Special handling below
+            elif type(instr) == Initialize:
+                pass  # Special handling below
             else:
                 optype = _known_qiskit_gate[type(instr)]
             qubits = [self.qbmap[qbit] for qbit in qargs]
@@ -324,6 +328,11 @@ class CircuitBuilder:
                 c_box = CircBox(sub_circ)
                 q_ctrl_box = QControlBox(c_box, instr.num_ctrl_qubits)
                 self.tkc.add_qcontrolbox(q_ctrl_box, qubits)
+
+            elif isinstance(instr, Initialize):
+                statevector_array = instr.params
+                pytket_state_prep_box = StatePreparationBox(statevector_array)
+                self.tkc.add_gate(pytket_state_prep_box, qubits)
 
             elif type(instr) == PauliEvolutionGate:
                 qpo = _qpo_from_peg(instr, qubits)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -264,14 +264,24 @@ def _string_to_circuit(
     for count, char in enumerate(reversed(circuit_string)):
         if char == "0":
             pass
-        if char in ("1", "-"):
+        elif char == "1":
             circ.X(count)
-        if char in ("+", "-", "r", "l"):
+        elif char == "+":
             circ.H(count)
-            if char == "r":
-                circ.S(count)
-            elif char == "l":
-                circ.Sdg(count)
+        elif char == "-":
+            circ.X(count)
+            circ.H(count)
+        elif char == "r":
+            circ.H(count)
+            circ.S(count)
+        elif char == "l":
+            circ.H(count)
+            circ.Sdg(count)
+        else:
+            raise ValueError(
+                f"Cannot parse string for character {char}."
+                + "The supported characters are {'0', '1', '+', '-', 'r', 'l'}."
+            )
 
     return circ
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -57,7 +57,6 @@ from qiskit.circuit.library import CRYGate, RYGate, PauliEvolutionGate, StatePre
 
 from qiskit.extensions.unitary import UnitaryGate  # type: ignore
 from qiskit.extensions import Initialize  # type: ignore
-from qiskit.quantum_info import Statevector
 from pytket.circuit import (  # type: ignore
     CircBox,
     Circuit,
@@ -377,7 +376,7 @@ class CircuitBuilder:
                         pytket_state_prep_box = StatePreparationBox(
                             amplitude_list, with_initial_reset=False
                         )
-                    reversed_qubits = list(reversed(qubits))
+                    reversed_qubits = qubits.reverse()
                     self.tkc.add_gate(pytket_state_prep_box, reversed_qubits)
 
                 elif isinstance(instr.params[0], complex) and len(instr.params) == 1:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -329,9 +329,12 @@ class CircuitBuilder:
                 self.tkc.add_qcontrolbox(q_ctrl_box, qubits)
 
             elif isinstance(instr, Initialize):
-                amplitude_list = instr.params
-                pytket_state_prep_box = StatePreparationBox(amplitude_list)
-                self.tkc.add_gate(pytket_state_prep_box, qubits)
+                # Check that the Initialize object is constructed with a list: 
+                # https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.initialize.html
+                if isinstance(instr.params, list):
+                    amplitude_list = instr.params
+                    pytket_state_prep_box = StatePreparationBox(amplitude_list)
+                    self.tkc.add_gate(pytket_state_prep_box, qubits)
 
             elif type(instr) == PauliEvolutionGate:
                 qpo = _qpo_from_peg(instr, qubits)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -329,7 +329,7 @@ class CircuitBuilder:
                 self.tkc.add_qcontrolbox(q_ctrl_box, qubits)
 
             elif isinstance(instr, Initialize):
-                # Check that the Initialize object is constructed with a list: 
+                # Check that the Initialize object is constructed with a list:
                 # https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.initialize.html
                 if isinstance(instr.params, list):
                     amplitude_list = instr.params

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -380,7 +380,7 @@ class CircuitBuilder:
                             amplitude_list, with_initial_reset=False
                         )
                     # Need to reverse qubits here (endian-ness)
-                    reversed_qubits = qubits.reverse()
+                    reversed_qubits = list(reversed(qubits))
                     self.tkc.add_gate(pytket_state_prep_box, reversed_qubits)
 
                 elif isinstance(instr.params[0], complex) and len(instr.params) == 1:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -329,8 +329,8 @@ class CircuitBuilder:
                 self.tkc.add_qcontrolbox(q_ctrl_box, qubits)
 
             elif isinstance(instr, Initialize):
-                statevector_array = instr.params
-                pytket_state_prep_box = StatePreparationBox(statevector_array)
+                amplitude_list = instr.params
+                pytket_state_prep_box = StatePreparationBox(amplitude_list)
                 self.tkc.add_gate(pytket_state_prep_box, qubits)
 
             elif type(instr) == PauliEvolutionGate:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -150,7 +150,7 @@ _qiskit_gates_other = {
     Measure: OpType.Measure,
     Reset: OpType.Reset,
     UnitaryGate: OpType.Unitary2qBox,
-    Initialize: OpType.StatePreparationBox
+    Initialize: OpType.StatePreparationBox,
 }
 
 _known_qiskit_gate = {**_qiskit_gates_1q, **_qiskit_gates_2q, **_qiskit_gates_other}
@@ -487,11 +487,11 @@ def append_tk_command_to_qiskit(
         # ILO-BE == DLO-LE; qiskit unitaries are ILO-LE == DLO-BE).
         return qcirc.append(g, qargs=list(reversed(qargs)))
     if optype == OpType.StatePreparationBox:
-        stateprep_op = Op.create(optype)
-        statevector_array = stateprep_op.get_statevector()
+        qargs = [qregmap[q.reg_name][q.index[0]] for q in args]
+        statevector_array = op.get_statevector()
         initializer = Initialize(statevector_array)
         return qcirc.append(initializer, qargs=list(reversed(qargs)))
-    
+
     if optype == OpType.Barrier:
         if any(q.type == UnitType.bit for q in args):
             raise NotImplementedError(

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -151,7 +151,7 @@ _qiskit_gates_other = {
     Reset: OpType.Reset,
     UnitaryGate: OpType.Unitary2qBox,
     Initialize: OpType.StatePreparationBox,
-    StatePreparation: OpType.StatePreparationBox
+    StatePreparation: OpType.StatePreparationBox,
 }
 
 _known_qiskit_gate = {**_qiskit_gates_1q, **_qiskit_gates_2q, **_qiskit_gates_other}
@@ -542,8 +542,13 @@ def append_tk_command_to_qiskit(
     if optype == OpType.StatePreparationBox:
         qargs = [qregmap[q.reg_name][q.index[0]] for q in args]
         statevector_array = op.get_statevector()
-        initializer = Initialize(statevector_array)
-        return qcirc.append(initializer, qargs=list(reversed(qargs)))
+        # check if the StatePreparationBox contains resets
+        if op.with_initial_reset():
+            initializer = Initialize(statevector_array)
+            return qcirc.append(initializer, qargs=list(reversed(qargs)))
+        else:
+            qiskit_state_prep_box = StatePreparation(statevector_array)
+            return qcirc.append(qiskit_state_prep_box, qargs=list(reversed(qargs)))
 
     if optype == OpType.Barrier:
         if any(q.type == UnitType.bit for q in args):

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -249,7 +249,8 @@ def _qpo_from_peg(peg: PauliEvolutionGate, qubits: List[Qubit]) -> QubitPauliOpe
 def _string_to_circuit(
     circuit_string: str, n_qubits: int, qiskit_instruction: Instruction
 ) -> Circuit:
-    """Helper function to handle strings in QuantumCircuit.initialize"""
+    """Helper function to handle strings in QuantumCircuit.initialize
+    and QuantumCircuit.prepare_state"""
 
     circ = Circuit(n_qubits)
     # Check if Instruction is Initialize or Statepreparation
@@ -258,6 +259,8 @@ def _string_to_circuit(
         for qubit in circ.qubits:
             circ.add_gate(OpType.Reset, [qubit])
 
+    # We iterate through the string in reverse to add the
+    # gates in the correct order (endian-ness).
     for count, char in enumerate(reversed(circuit_string)):
         if char == "0":
             pass
@@ -376,6 +379,7 @@ class CircuitBuilder:
                         pytket_state_prep_box = StatePreparationBox(
                             amplitude_list, with_initial_reset=False
                         )
+                    # Need to reverse qubits here (endian-ness)
                     reversed_qubits = qubits.reverse()
                     self.tkc.add_gate(pytket_state_prep_box, reversed_qubits)
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -279,7 +279,7 @@ def _string_to_circuit(
             circ.Sdg(count)
         else:
             raise ValueError(
-                f"Cannot parse string for character {char}."
+                f"Cannot parse string for character {char}. "
                 + "The supported characters are {'0', '1', '+', '-', 'r', 'l'}."
             )
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -303,8 +303,6 @@ class CircuitBuilder:
                         )
             elif type(instr) == PauliEvolutionGate:
                 pass  # Special handling below
-            elif type(instr) == Initialize:
-                pass  # Special handling below
             else:
                 optype = _known_qiskit_gate[type(instr)]
             qubits = [self.qbmap[qbit] for qbit in qargs]

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -57,7 +57,7 @@ from qiskit.circuit.library import CRYGate, RYGate, PauliEvolutionGate, StatePre
 
 from qiskit.extensions.unitary import UnitaryGate  # type: ignore
 from qiskit.extensions import Initialize  # type: ignore
-from qiskit.quantum_info import Statevector 
+from qiskit.quantum_info import Statevector
 from pytket.circuit import (  # type: ignore
     CircBox,
     Circuit,

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -65,7 +65,7 @@ def _get_qiskit_statevector(qc: QuantumCircuit) -> np.ndarray:
     back = Aer.get_backend("aer_simulator_statevector")
     qc.save_state()
     job = back.run(qc)
-    return job.result().data()["statevector"].reverse_qargs().data
+    return np.array(job.result().data()["statevector"].reverse_qargs().data)
 
 
 def test_classical_barrier_error() -> None:

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -764,7 +764,7 @@ def test_qcontrolbox_conversion() -> None:
 
 def test_state_prep_conversion() -> None:
     # State prep with real amplitudes
-    ghz_state = 1 / np.sqrt(2) * np.array([1, 0, 0, 0, 0, 0, 0, 1])
+    ghz_state = 1 / np.sqrt(2) * [1, 0, 0, 0, 0, 0, 0, 1]
     qc_sp = QuantumCircuit(3)
     qc_sp.initialize(ghz_state)
     tk_sp = qiskit_to_tk(qc_sp)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -773,11 +773,15 @@ def test_state_prep_conversion() -> None:
     assert compare_statevectors(tk_sp.get_statevector(), ghz_state)
     # State prep with complex amplitudes
     qc_sp2 = QuantumCircuit(2)
-    complex_statvector = np.array([0, 1/np.sqrt(2), -1.j/np.sqrt(2), 0])
-    qc_sp2.initialize(complex_statvector, qc_sp2.qubits) 
-    tk_sp2 = qiskit_to_tk(qc_sp2)  
+    complex_statvector = np.array([0, 1 / np.sqrt(2), -1.0j / np.sqrt(2), 0])
+    qc_sp2.initialize(complex_statvector, qc_sp2.qubits)
+    tk_sp2 = qiskit_to_tk(qc_sp2)
     assert tk_sp2.n_gates_of_type(OpType.StatePreparationBox) == 1
     assert tk_sp2.n_gates == 1
     assert compare_statevectors(tk_sp2.get_statevector(), complex_statvector)
     # test tket -> qiskit conversion
     converted_qiskit_qc = tk_to_qiskit(tk_sp2)
+    print(converted_qiskit_qc)
+
+
+test_state_prep_conversion()

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -783,3 +783,24 @@ def test_state_prep_conversion() -> None:
     # test tket -> qiskit conversion
     converted_qiskit_qc = tk_to_qiskit(tk_sp2)
     assert converted_qiskit_qc.count_ops()["initialize"] == 1
+
+from pytket.circuit.display import view_browser
+
+def test_state_prep_conversion_with_str_and_int():
+    qc = QuantumCircuit(5)
+    qc.initialize("rl+-1")
+    tk_circ = qiskit_to_tk(qc)
+    assert tk_circ.n_gates_of_type(OpType.Reset) == 5
+    assert tk_circ.n_gates_of_type(OpType.H) == 4
+    assert tk_circ.n_gates_of_type(OpType.X) == 2
+    qc = QuantumCircuit(4)
+    qc.initialize(7, qc.qubits)
+    tkc7 = qiskit_to_tk(qc)
+    print(tkc7.get_statevector())
+    assert n_gates_of_type(OpType.X) == 3
+
+
+
+
+
+test_state_prep_conversion_with_str_and_int()

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -779,7 +779,7 @@ def test_tk_to_qiskit_redundancies() -> None:
     qc_h = tk_to_qiskit(h_circ)
     assert qc_h.count_ops()["h"] == 2
 
-    
+
 def test_ccx_conversion() -> None:
     # https://github.com/CQCL/pytket-qiskit/issues/117
     c00 = QuantumCircuit(3)
@@ -806,7 +806,8 @@ def test_ccx_conversion() -> None:
         qiskit_to_tk(c11).get_unitary(),
         Circuit(3).CCX(0, 1, 2).get_unitary(),
     )
- 
+
+
 # https://github.com/CQCL/pytket-qiskit/issues/100
 def test_state_prep_conversion_array_or_list() -> None:
     # State prep with list of real amplitudes

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -781,7 +781,4 @@ def test_state_prep_conversion() -> None:
     assert compare_statevectors(tk_sp2.get_statevector(), complex_statvector)
     # test tket -> qiskit conversion
     converted_qiskit_qc = tk_to_qiskit(tk_sp2)
-    print(converted_qiskit_qc)
-
-
-test_state_prep_conversion()
+    assert converted_qiskit_qc.count_ops()['initialize'] == 1

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -779,3 +779,5 @@ def test_state_prep_conversion() -> None:
     assert tk_sp2.n_gates_of_type(OpType.StatePreparationBox) == 1
     assert tk_sp2.n_gates == 1
     assert compare_statevectors(tk_sp2.get_statevector(), complex_statvector)
+    # test tket -> qiskit conversion
+    converted_qiskit_qc = tk_to_qiskit(tk_sp2)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -781,4 +781,4 @@ def test_state_prep_conversion() -> None:
     assert compare_statevectors(tk_sp2.get_statevector(), complex_statvector)
     # test tket -> qiskit conversion
     converted_qiskit_qc = tk_to_qiskit(tk_sp2)
-    assert converted_qiskit_qc.count_ops()['initialize'] == 1
+    assert converted_qiskit_qc.count_ops()["initialize"] == 1

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -766,12 +766,11 @@ def test_state_prep_conversion() -> None:
     # State prep with list of real amplitudes
     ghz_state = [1 / np.sqrt(2), 0, 0, 0, 0, 0, 0, 1 / np.sqrt(2)]
     qc_sp = QuantumCircuit(3)
-    qc_sp.initialize(ghz_state)
+    qc_sp.prepare_state(ghz_state)
     tk_sp = qiskit_to_tk(qc_sp)
     assert tk_sp.n_gates_of_type(OpType.StatePreparationBox) == 1
     assert tk_sp.n_gates == 1
-    DecomposeBoxes().apply(tk_sp)
-    assert tk_sp.n_gates_of_type(OpType.Reset) == 3
+    assert compare_statevectors(tk_sp.get_statevector(), ghz_state)
     # State prep with ndarray of complex amplitudes
     qc_sp2 = QuantumCircuit(2)
     complex_statvector = np.array([0, 1 / np.sqrt(2), -1.0j / np.sqrt(2), 0])
@@ -796,6 +795,8 @@ def test_state_prep_conversion_with_str_and_int():
     assert tk_circ.n_gates_of_type(OpType.H) == 4
     assert tk_circ.n_gates_of_type(OpType.X) == 2
     qc = QuantumCircuit(4)
-    qc.initialize(7, qc.qubits)
+    qc.prepare_state(7, qc.qubits)
     tkc7 = qiskit_to_tk(qc)
     assert tkc7.n_gates_of_type(OpType.X) == 3
+    expected_sv = np.array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0])
+    assert compare_statevectors(tkc7.get_statevector(), expected_sv)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -764,7 +764,7 @@ def test_qcontrolbox_conversion() -> None:
 
 def test_state_prep_conversion() -> None:
     # State prep with real amplitudes
-    ghz_state = 1 / np.sqrt(2) * [1, 0, 0, 0, 0, 0, 0, 1]
+    ghz_state = [1 / np.sqrt(2), 0, 0, 0, 0, 0, 0, 1 / np.sqrt(2)]
     qc_sp = QuantumCircuit(3)
     qc_sp.initialize(ghz_state)
     tk_sp = qiskit_to_tk(qc_sp)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -770,8 +770,8 @@ def test_state_prep_conversion() -> None:
     tk_sp = qiskit_to_tk(qc_sp)
     assert tk_sp.n_gates_of_type(OpType.StatePreparationBox) == 1
     assert tk_sp.n_gates == 1
-    ghz_array = np.array(ghz_state)
-    assert compare_statevectors(tk_sp.get_statevector(), ghz_array)
+    DecomposeBoxes().apply(tk_sp)
+    assert tk_sp.n_gates_of_type(OpType.Reset) == 3
     # State prep with ndarray of complex amplitudes
     qc_sp2 = QuantumCircuit(2)
     complex_statvector = np.array([0, 1 / np.sqrt(2), -1.0j / np.sqrt(2), 0])
@@ -779,12 +779,14 @@ def test_state_prep_conversion() -> None:
     tk_sp2 = qiskit_to_tk(qc_sp2)
     assert tk_sp2.n_gates_of_type(OpType.StatePreparationBox) == 1
     assert tk_sp2.n_gates == 1
-    assert compare_statevectors(tk_sp2.get_statevector(), complex_statvector)
     # test tket -> qiskit conversion
     converted_qiskit_qc = tk_to_qiskit(tk_sp2)
     assert converted_qiskit_qc.count_ops()["initialize"] == 1
+    tk_sp3 = qiskit_to_tk(converted_qiskit_qc)
+    # check circuit decomposes as expected
+    DecomposeBoxes().apply(tk_sp3)
+    assert tk_sp3.n_gates_of_type(OpType.Reset) == 2
 
-from pytket.circuit.display import view_browser
 
 def test_state_prep_conversion_with_str_and_int():
     qc = QuantumCircuit(5)
@@ -796,11 +798,4 @@ def test_state_prep_conversion_with_str_and_int():
     qc = QuantumCircuit(4)
     qc.initialize(7, qc.qubits)
     tkc7 = qiskit_to_tk(qc)
-    print(tkc7.get_statevector())
-    assert n_gates_of_type(OpType.X) == 3
-
-
-
-
-
-test_state_prep_conversion_with_str_and_int()
+    assert tkc7.n_gates_of_type(OpType.X) == 3

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -780,8 +780,6 @@ def test_tk_to_qiskit_redundancies() -> None:
     assert qc_h.count_ops()["h"] == 2
 
 
-from pytket.circuit.display import view_browser
-
 # https://github.com/CQCL/pytket-qiskit/issues/100
 def test_state_prep_conversion_array_or_list() -> None:
     # State prep with list of real amplitudes
@@ -824,6 +822,8 @@ def test_state_prep_conversion_with_int() -> None:
     int_statevector = Statevector.from_int(5, 8)
     qc_s = QuantumCircuit(3)
     qc_s.prepare_state(int_statevector)
+    # unfortunately Aer doesn't support state_preparation
+    # instructions so we decompose first
     d_qc_s = qc_s.decompose(reps=5)
     sv_int = _get_qiskit_statevector(d_qc_s)
     tkc_int = qiskit_to_tk(qc_s)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -783,7 +783,7 @@ def test_tk_to_qiskit_redundancies() -> None:
 # https://github.com/CQCL/pytket-qiskit/issues/100
 def test_state_prep_conversion_array_or_list() -> None:
     # State prep with list of real amplitudes
-    ghz_state_permuted = [0, 0, 1 / np.sqrt(2), 0, 0, 0, 0, 1 / np.sqrt(2)]
+    ghz_state_permuted = np.array([0, 0, 1 / np.sqrt(2), 0, 0, 0, 0, 1 / np.sqrt(2)])
     qc_sp = QuantumCircuit(3)
     qc_sp.prepare_state(ghz_state_permuted)
     tk_sp = qiskit_to_tk(qc_sp)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -763,15 +763,16 @@ def test_qcontrolbox_conversion() -> None:
 
 
 def test_state_prep_conversion() -> None:
-    # State prep with real amplitudes
+    # State prep with list of real amplitudes
     ghz_state = [1 / np.sqrt(2), 0, 0, 0, 0, 0, 0, 1 / np.sqrt(2)]
     qc_sp = QuantumCircuit(3)
     qc_sp.initialize(ghz_state)
     tk_sp = qiskit_to_tk(qc_sp)
     assert tk_sp.n_gates_of_type(OpType.StatePreparationBox) == 1
     assert tk_sp.n_gates == 1
-    assert compare_statevectors(tk_sp.get_statevector(), ghz_state)
-    # State prep with complex amplitudes
+    ghz_array = np.array(ghz_state)
+    assert compare_statevectors(tk_sp.get_statevector(), ghz_array)
+    # State prep with ndarray of complex amplitudes
     qc_sp2 = QuantumCircuit(2)
     complex_statvector = np.array([0, 1 / np.sqrt(2), -1.0j / np.sqrt(2), 0])
     qc_sp2.initialize(complex_statvector, qc_sp2.qubits)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -760,3 +760,22 @@ def test_qcontrolbox_conversion() -> None:
     tkc2 = qiskit_to_tk(qc2)
     assert tkc2.n_gates == 3
     assert tkc2.n_gates_of_type(OpType.QControlBox) == 3
+
+
+def test_state_prep_conversion() -> None:
+    # State prep with real amplitudes
+    ghz_state = 1 / np.sqrt(2) * np.array([1, 0, 0, 0, 0, 0, 0, 1])
+    qc_sp = QuantumCircuit(3)
+    qc_sp.initialize(ghz_state)
+    tk_sp = qiskit_to_tk(qc_sp)
+    assert tk_sp.n_gates_of_type(OpType.StatePreparationBox) == 1
+    assert tk_sp.n_gates == 1
+    assert compare_statevectors(tk_sp.get_statevector(), ghz_state)
+    # State prep with complex amplitudes
+    qc_sp2 = QuantumCircuit(2)
+    complex_statvector = np.array([0, 1/np.sqrt(2), -1.j/np.sqrt(2), 0])
+    qc_sp2.initialize(complex_statvector, qc_sp2.qubits) 
+    tk_sp2 = qiskit_to_tk(qc_sp2)  
+    assert tk_sp2.n_gates_of_type(OpType.StatePreparationBox) == 1
+    assert tk_sp2.n_gates == 1
+    assert compare_statevectors(tk_sp2.get_statevector(), complex_statvector)


### PR DESCRIPTION
Relates to issue https://github.com/CQCL/pytket-qiskit/issues/100

Adding handling of qiskit circuits with `Initialize` and `StatePreparation` operations in the converters using the new `StatePreparationBox`

Previously users would have had to use `QuantumCircuit.decompose()` multiple times for this to work.

I've decided not to add logic for handling multiplexors as this would be more complicated and probably of limited value for the user.

[Initialize](https://qiskit.org/documentation/stubs/qiskit.circuit.QuantumCircuit.initialize.html) inserts resets whereas [StatePreparation](https://qiskit.org/documentation/stubs/qiskit.circuit.library.StatePreparation.html) does not.

There are also several ways of constructing these (str, list, int) which I've tried to handle.

I have not added support for creating a qiskit `StatePreparation` instruction with a qiskit `Statevector` object. Let me know if I should add this.
EDIT: Turns out the `Statevector` case is handled by what I've done already.

I've also used `isinstance(a, mytype)` rather than using `type(a) == mytype` as apparently this is better.
https://switowski.com/blog/type-vs-isinstance/