### PR TITLE
Support ECR gate in the gateset rebase and use pytest-rerunfailures

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,8 @@
 Changelog
 ~~~~~~~~~
+0.40.0 (June 2023)(unreleased)
+------------------------------
+* Added support for the {X, SX, Rz, ECR} in the default compilation pass for :py:class:`IBMQBackend` and :py:class:`IBMQEmulatorBackend`. This is the set of gates used by some of the new IBM devices.
 
 0.39.0 (May 2023)
 -----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,12 +1,9 @@
 Changelog
 ~~~~~~~~~
-0.40.0 (June 2023)(unreleased)
-------------------------------
+
+0.40.0(unreleased)
+------------------
 * Added support for the {X, SX, Rz, ECR} in the default compilation pass for :py:class:`IBMQBackend` and :py:class:`IBMQEmulatorBackend`. This is the set of gates used by some of the new IBM devices.
-
-0.40.0rc1 (unreleased)
-----------------------
-
 * IBM devices are now accessed using the `qiskit-ibm-provider <https://github.com/Qiskit/qiskit-ibm-provider>`_ instead of the deprecated :py:class:`IBMQ`. This allows the newest IBM devices and simulators to be accessed through the pytket-qiskit extension.
 * Fix to the `tk_to_qiskit` converter to prevent cancellation of redundant gates when converting to qiskit.
 * Handle qiskit circuits with :py:class:`Initialize` and :py:class:`StatePreparation` instructions in the :py:meth:`qiskit_to_tk` converter. The :py:meth:`tk_to_qiskit` converter now handles :py:class:`StatePreparationBox`.

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -127,7 +127,6 @@ class NoIBMQAccountError(Exception):
 class GateSet(Enum):
     X_SX_RZ_CX = {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
     X_SX_RZ_ECR = {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}
-    UNKNOWN = None
 
 
 class UnsupportedGateSetException(Exception):

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -123,9 +123,13 @@ class NoIBMQAccountError(Exception):
         )
 
 
+_gateset_with_ecr = {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}
+_gateset_with_cx = {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
+
+
 class GateSet(Enum):
-    X_SX_RZ_CX = {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
-    X_SX_RZ_ECR = {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}
+    X_SX_RZ_CX = _gateset_with_cx
+    X_SX_RZ_ECR = _gateset_with_ecr
 
 
 class NoRebaseException(Exception):

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -28,6 +28,7 @@ from typing import (
     TYPE_CHECKING,
     Tuple,
     Union,
+    Set
 )
 from warnings import warn
 from enum import Enum
@@ -169,7 +170,7 @@ ecr_rebase = RebaseCustom(
 )
 
 
-def _get_primitive_gates(gateset: set[OpType], backend: "QiskitBackend") -> set[OpType]:
+def _get_primitive_gates(gateset: Set[OpType], backend: "QiskitBackend") -> Set[OpType]:
     if gateset >= GateSet.X_SX_RZ_CX.value:
         return GateSet.X_SX_RZ_CX.value
     elif gateset >= GateSet.X_SX_RZ_ECR.value:

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -415,7 +415,13 @@ class IBMQBackend(Backend):
         # https://cqcl.github.io/pytket-qiskit/api/index.html#default-compilation
         # Edit this docs source file -> pytket-qiskit/docs/intro.txt
         if optimisation_level == 0:
-            passlist.append(self.rebase_pass())
+            if self._primitive_gates == {OpType.X, OpType.SX, OpType.Rz, OpType.CX} or {
+                OpType.X,
+                OpType.SX,
+                OpType.Rz,
+                OpType.ECR,
+            }:
+                passlist.append(self.rebase_pass())
         elif optimisation_level == 1:
             passlist.append(SynthesiseTket())
         elif optimisation_level == 2:
@@ -458,7 +464,13 @@ class IBMQBackend(Backend):
                     SynthesiseTket(),
                 ]
             )
-        passlist.extend([self.rebase_pass(), RemoveRedundancies()])
+        if self._primitive_gates == {OpType.X, OpType.SX, OpType.Rz, OpType.CX} or {
+            OpType.X,
+            OpType.SX,
+            OpType.Rz,
+            OpType.ECR,
+        }:
+            passlist.extend([self.rebase_pass(), RemoveRedundancies()])
         if optimisation_level > 0:
             passlist.append(
                 SimplifyInitial(allow_classical=False, create_all_qubits=True)

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -220,7 +220,7 @@ class IBMQBackend(Backend):
         self._service = QiskitRuntimeService(channel="ibm_quantum", token=token)
         self._session = Session(service=self._service, backend=backend_name)
 
-        self.standard_gateset  = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
+        self._standard_gateset  = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
 
         self._primitive_gates = GateSet["X_SX_RZ_CX"] if gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX} else GateSet["X_SX_RZ_ECR"]
         self._monitor = monitor

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -297,7 +297,7 @@ class IBMQBackend(Backend):
 
     @primitive_gates.setter
     def primitive_gates(self, primitives):
-        if primitives != GateSet.X_SX_RZ_CX or GateSet.X_SX_RZ_ECR:
+        if primitives != GateSet.X_SX_RZ_CX.value or GateSet.X_SX_RZ_ECR.value:
             raise UnsupportedGateSetException(primitives)
         self._primitive_gates = primitives
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -128,6 +128,15 @@ class GateSet(Enum):
     X_SX_RZ_ECR = {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}
 
 
+class NoRebaseException(Exception):
+    "Exception raised in the case that no gateset rebase is supported for an IBMBackend"
+
+    def __init__(self) -> None:
+        super().__init__(
+            "No rebase is available to convert to the supported gateset of this Backend"
+        )
+
+
 def _save_ibmq_auth(qiskit_config: Optional[QiskitConfig]) -> None:
     token = None
     if qiskit_config is not None:
@@ -476,8 +485,10 @@ class IBMQBackend(Backend):
     def rebase_pass(self) -> BasePass:
         if self._primitive_gates == GateSet.X_SX_RZ_CX.value:
             return auto_rebase_pass(GateSet.X_SX_RZ_CX.value)
+        elif self._primitive_gates == GateSet.X_SX_RZ_ECR.value:
+            return auto_rebase_pass(GateSet.X_SX_RZ_ECR.value)
         else:
-            return ecr_rebase
+            raise NoRebaseException
 
     def process_circuits(
         self,

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -148,7 +148,7 @@ _cx_replacement_with_ecr = (
 _tk1_replacement_function = _TK1_to_X_SX_Rz
 
 ecr_rebase = RebaseCustom(
-    gateset={OpType.X, OpType.SX, OpType.Rz, OpType.CX},
+    gateset={OpType.X, OpType.SX, OpType.Rz, OpType.ECR},
     cx_replacement=_cx_replacement_with_ecr,
     tk1_replacement=_tk1_replacement_function,
 )

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -164,7 +164,7 @@ _tk1_replacement_function = get_TK1_decomposition_function(
 )
 
 ecr_rebase = RebaseCustom(
-    gateset={OpType.X, OpType.SX, OpType.Rz, OpType.ECR},
+    gateset=GateSet.X_SX_RZ_ECR.value,
     cx_replacement=_cx_replacement_with_ecr,
     tk1_replacement=_tk1_replacement_function,
 )
@@ -483,9 +483,9 @@ class IBMQBackend(Backend):
         return (str, int, int, str)
 
     def rebase_pass(self) -> BasePass:
-        if self._primitive_gates == {OpType.X, OpType.SX, OpType.Rz, OpType.CX}:
-            return auto_rebase_pass({OpType.X, OpType.SX, OpType.Rz, OpType.CX})
-        elif self._primitive_gates == {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}:
+        if self._primitive_gates == GateSet.X_SX_RZ_CX.value:
+            return auto_rebase_pass(GateSet.X_SX_RZ_CX.value)
+        elif self._primitive_gates == GateSet.X_SX_RZ_ECR.value:
             return ecr_rebase
         else:
             raise NoRebaseException

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -239,7 +239,7 @@ class IBMQBackend(Backend):
         self._service = QiskitRuntimeService(channel="ibm_quantum", token=token)
         self._session = Session(service=self._service, backend=backend_name)
 
-        self._primitive_gates = _get_primitive_gates(gate_set)
+        self._primitive_gates = _get_primitive_gates(gate_set, self._backend)
 
         self._monitor = monitor
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -130,7 +130,7 @@ class GateSet(Enum):
 
 
 class UnsupportedGateSetException(Exception):
-    "Exception raised in the case that no gateset rebase is supported for an IBMBackend"
+    "Exception raised in the case that no gateset rebase is supported for an IBMQBackend"
 
     def __init__(self, gateset) -> None:
         super().__init__(f"Conversion to the {gateset} gateset is unsupported.")

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -169,13 +169,13 @@ ecr_rebase = RebaseCustom(
 )
 
 
-def _get_primitive_gates(gateset: set[OpType]) -> Optional[GateSet]:
+def _get_primitive_gates(gateset: set[OpType], backend: "QiskitBackend") -> set[OpType]:
     if gateset >= GateSet.X_SX_RZ_CX.value:
-        return GateSet.X_SX_RZ_CX
+        return GateSet.X_SX_RZ_CX.value
     elif gateset >= GateSet.X_SX_RZ_ECR.value:
-        return GateSet.X_SX_RZ_ECR
+        return GateSet.X_SX_RZ_ECR.value
     else:
-        return None
+        return _tk_gate_set(backend)
 
 
 class IBMQBackend(Backend):

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -202,9 +202,7 @@ class IBMQBackend(Backend):
         :type token: Optional[str]
         """
         super().__init__()
-        self._pytket_config = (
-            QiskitConfig.from_default_config_file()
-        )  # it looks like this is not working?
+        self._pytket_config = QiskitConfig.from_default_config_file()
         self._provider = (
             self._get_provider(instance=instance, qiskit_config=self._pytket_config)
             if provider is None

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -472,10 +472,10 @@ class IBMQBackend(Backend):
         return (str, int, int, str)
 
     def rebase_pass(self) -> BasePass:
-        if self._primitive_gates == {OpType.X, OpType.SX, OpType.Rz, OpType.CX}:
+        if self._primitive_gates == {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}:
             return ecr_rebase
         else:
-            return auto_rebase_pass(self.primitive_gates)
+            return auto_rebase_pass(self._primitive_gates)
 
     def process_circuits(
         self,

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -222,7 +222,7 @@ class IBMQBackend(Backend):
 
         self._standard_gateset  = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
 
-        self._primitive_gates = GateSet["X_SX_RZ_CX"] if gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX} else GateSet["X_SX_RZ_ECR"]
+        self._primitive_gates = GateSet.X_SX_RZ_CX.value if gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX} else GateSet.X_SX_RZ_ECR.value
         self._monitor = monitor
 
         # cache of results keyed by job id and circuit index
@@ -469,8 +469,8 @@ class IBMQBackend(Backend):
         return (str, int, int, str)
 
     def rebase_pass(self) -> BasePass:
-        if self._primitive_gates == GateSet["X_SX_RZ_CX"]:
-            return auto_rebase_pass({OpType.X, OpType.SX, OpType.Rz, OpType.CX})
+        if self._primitive_gates == GateSet.X_SX_RZ_CX.value:
+            return auto_rebase_pass(GateSet.X_SX_RZ_CX.value)
         else:
             return ecr_rebase
         

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -122,6 +122,7 @@ class NoIBMQAccountError(Exception):
             " or using :py:meth:`pytket.extensions.qiskit.set_ibmq_config` first."
         )
 
+
 class GateSet(Enum):
     X_SX_RZ_CX = {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
     X_SX_RZ_ECR = {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}
@@ -220,9 +221,13 @@ class IBMQBackend(Backend):
         self._service = QiskitRuntimeService(channel="ibm_quantum", token=token)
         self._session = Session(service=self._service, backend=backend_name)
 
-        self._standard_gateset  = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
+        self._standard_gateset = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
 
-        self._primitive_gates = GateSet.X_SX_RZ_CX.value if gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX} else GateSet.X_SX_RZ_ECR.value
+        self._primitive_gates = (
+            GateSet.X_SX_RZ_CX.value
+            if gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
+            else GateSet.X_SX_RZ_ECR.value
+        )
         self._monitor = monitor
 
         # cache of results keyed by job id and circuit index
@@ -473,7 +478,6 @@ class IBMQBackend(Backend):
             return auto_rebase_pass(GateSet.X_SX_RZ_CX.value)
         else:
             return ecr_rebase
-        
 
     def process_circuits(
         self,

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -220,7 +220,7 @@ class IBMQBackend(Backend):
         self._service = QiskitRuntimeService(channel="ibm_quantum", token=token)
         self._session = Session(service=self._service, backend=backend_name)
 
-        self._standard_gates  = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
+        self.standard_gateset  = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
 
         self._primitive_gates = GateSet["X_SX_RZ_CX"] if gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX} else GateSet["X_SX_RZ_ECR"]
         self._monitor = monitor

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -486,7 +486,7 @@ class IBMQBackend(Backend):
         if self._primitive_gates == GateSet.X_SX_RZ_CX.value:
             return auto_rebase_pass(GateSet.X_SX_RZ_CX.value)
         elif self._primitive_gates == GateSet.X_SX_RZ_ECR.value:
-            return auto_rebase_pass(GateSet.X_SX_RZ_ECR.value)
+            return ecr_rebase
         else:
             raise NoRebaseException
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -163,8 +163,12 @@ _tk1_replacement_function = get_TK1_decomposition_function(
     {OpType.X, OpType.SX, OpType.Rz}
 )
 
+_gateset_with_ecr = {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}
+
+_gateset_with_cx = {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
+
 ecr_rebase = RebaseCustom(
-    gateset={OpType.X, OpType.SX, OpType.Rz, OpType.ECR},
+    gateset=_gateset_with_ecr,
     cx_replacement=_cx_replacement_with_ecr,
     tk1_replacement=_tk1_replacement_function,
 )
@@ -483,9 +487,9 @@ class IBMQBackend(Backend):
         return (str, int, int, str)
 
     def rebase_pass(self) -> BasePass:
-        if self._primitive_gates == GateSet.X_SX_RZ_CX.value:
-            return auto_rebase_pass(GateSet.X_SX_RZ_CX.value)
-        elif self._primitive_gates == GateSet.X_SX_RZ_ECR.value:
+        if self._primitive_gates == _gateset_with_cx:
+            return auto_rebase_pass(_gateset_with_cx)
+        elif self._primitive_gates == _gateset_with_ecr:
             return ecr_rebase
         else:
             raise NoRebaseException

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -28,7 +28,7 @@ from typing import (
     TYPE_CHECKING,
     Tuple,
     Union,
-    Set
+    Set,
 )
 from warnings import warn
 from enum import Enum

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -130,7 +130,7 @@ class GateSet(Enum):
 
 
 class UnsupportedGateSetException(Exception):
-    "Exception raised in the case that no gateset rebase is supported for an IBMQBackend"
+    "Exception raised when no gateset rebase is supported for an IBMQBackend"
 
     def __init__(self, gateset) -> None:
         super().__init__(f"Conversion to the {gateset} gateset is unsupported.")

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -170,13 +170,13 @@ ecr_rebase = RebaseCustom(
 )
 
 
-def _get_primitive_gates(gateset: Set[OpType], backend: "QiskitBackend") -> Set[OpType]:
+def _get_primitive_gates(gateset: Set[OpType]) -> Set[OpType]:
     if gateset >= GateSet.X_SX_RZ_CX.value:
         return GateSet.X_SX_RZ_CX.value
     elif gateset >= GateSet.X_SX_RZ_ECR.value:
         return GateSet.X_SX_RZ_ECR.value
     else:
-        return _tk_gate_set(backend)
+        return gateset
 
 
 class IBMQBackend(Backend):
@@ -239,7 +239,7 @@ class IBMQBackend(Backend):
         self._service = QiskitRuntimeService(channel="ibm_quantum", token=token)
         self._session = Session(service=self._service, backend=backend_name)
 
-        self._primitive_gates = _get_primitive_gates(gate_set, self._backend)
+        self._primitive_gates = _get_primitive_gates(gate_set)
 
         self._monitor = monitor
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -238,11 +238,11 @@ class IBMQBackend(Backend):
         self._service = QiskitRuntimeService(channel="ibm_quantum", token=token)
         self._session = Session(service=self._service, backend=backend_name)
 
-        self._standard_gateset = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
+        self._standard_gateset = gate_set >= _gateset_with_cx
 
         self._primitive_gates = (
             GateSet.X_SX_RZ_CX.value
-            if gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
+            if gate_set >= _gateset_with_cx
             else GateSet.X_SX_RZ_ECR.value
         )
         self._monitor = monitor

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -413,7 +413,7 @@ class IBMQBackend(Backend):
         # https://cqcl.github.io/pytket-qiskit/api/index.html#default-compilation
         # Edit this docs source file -> pytket-qiskit/docs/intro.txt
         if optimisation_level == 0:
-                passlist.append(self.rebase_pass())
+            passlist.append(self.rebase_pass())
         elif optimisation_level == 1:
             passlist.append(SynthesiseTket())
         elif optimisation_level == 2:

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -167,10 +167,6 @@ _tk1_replacement_function = get_TK1_decomposition_function(
     {OpType.X, OpType.SX, OpType.Rz}
 )
 
-_gateset_with_ecr = {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}
-
-_gateset_with_cx = {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
-
 ecr_rebase = RebaseCustom(
     gateset=_gateset_with_ecr,
     cx_replacement=_cx_replacement_with_ecr,

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -297,7 +297,7 @@ class IBMQBackend(Backend):
 
     @primitive_gates.setter
     def primitive_gates(self, primitives):
-        if primitives is None:
+        if primitives != GateSet.X_SX_RZ_CX or GateSet.X_SX_RZ_ECR:
             raise UnsupportedGateSetException(primitives)
         self._primitive_gates = primitives
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -31,7 +31,6 @@ from typing import (
     Set,
 )
 from warnings import warn
-from enum import Enum
 
 import qiskit  # type: ignore
 from qiskit import IBMQ

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -126,6 +126,7 @@ class NoIBMQAccountError(Exception):
 class GateSet(Enum):
     X_SX_RZ_CX = {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
     X_SX_RZ_ECR = {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}
+    UNKNOWN = None 
 
 
 class NoRebaseException(Exception):
@@ -230,13 +231,12 @@ class IBMQBackend(Backend):
         self._service = QiskitRuntimeService(channel="ibm_quantum", token=token)
         self._session = Session(service=self._service, backend=backend_name)
 
-        self._standard_gateset = gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
-
         self._primitive_gates = (
             GateSet.X_SX_RZ_CX.value
             if gate_set >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
             else GateSet.X_SX_RZ_ECR.value
         )
+
         self._monitor = monitor
 
         # cache of results keyed by job id and circuit index

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.16",
+        "pytket ~= 1.15",
         "qiskit ~= 0.42.1",
         "qiskit-ibm-runtime ~= 0.9.2",
         "qiskit-aer ~= 0.12.0",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.15",
+        "pytket ~= 1.16",
         "qiskit ~= 0.42.1",
         "qiskit-ibm-runtime ~= 0.9.2",
         "qiskit-aer ~= 0.12.0",

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -445,7 +445,7 @@ def test_nshots_batching(manila_backend: IBMQBackend) -> None:
         # ensure shared backend is reset for other tests
         backend._MACHINE_DEBUG = False
 
-
+@pytest.mark.flaky(reruns=3, rerun_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_nshots(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     for b in [AerBackend(), manila_emulator_backend]:
@@ -807,7 +807,7 @@ def test_operator_expectation_value() -> None:
     e = AerBackend().get_operator_expectation_value(c1, op)
     assert np.isclose(e, 1.0)
 
-
+@pytest.mark.flaky(reruns=3, rerun_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ibmq_emulator(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert manila_emulator_backend._noise_model is not None
@@ -1084,7 +1084,7 @@ def test_postprocess(lima_backend: IBMQBackend) -> None:
     assert all(ppcmd.op.type == OpType.ClassicalTransform for ppcmd in ppcmds)
     b.cancel(h)
 
-
+@pytest.mark.flaky(reruns=3, rerun_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert manila_emulator_backend.supports_contextual_optimisation
@@ -1126,7 +1126,7 @@ def test_available_devices(ibm_provider: IBMProvider) -> None:
     backend_info_list = IBMQBackend.available_devices()
     assert len(backend_info_list) > 0
 
-
+@pytest.mark.flaky(reruns=3, rerun_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_backendinfo_serialization1(
     manila_emulator_backend: IBMQEmulatorBackend,
@@ -1180,7 +1180,7 @@ def test_sim_qubit_order() -> None:
     s = backend.run_circuit(circ).get_state()
     assert np.isclose(abs(s[2]), 1.0)
 
-
+@pytest.mark.flaky(reruns=3, rerun_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_requrired_predicates(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     # https://github.com/CQCL/pytket-qiskit/issues/93

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -195,7 +195,7 @@ def test_noise(manila_backend: IBMQBackend) -> None:
     assert shots.shape == (10, 4)
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_process_characterisation(manila_backend: IBMQBackend) -> None:
 
@@ -446,7 +446,7 @@ def test_nshots_batching(manila_backend: IBMQBackend) -> None:
         backend._MACHINE_DEBUG = False
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_nshots(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     for b in [AerBackend(), manila_emulator_backend]:
@@ -672,7 +672,7 @@ def test_operator() -> None:
 
 
 # TKET-1432 this was either too slow or consumed too much memory when bugged
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_expectation_bug() -> None:
     backend = AerStateBackend()
     # backend.compile_circuit(circuit)
@@ -809,7 +809,7 @@ def test_operator_expectation_value() -> None:
     assert np.isclose(e, 1.0)
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ibmq_emulator(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert manila_emulator_backend._noise_model is not None
@@ -1087,7 +1087,7 @@ def test_postprocess(lima_backend: IBMQBackend) -> None:
     b.cancel(h)
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert manila_emulator_backend.supports_contextual_optimisation
@@ -1104,7 +1104,7 @@ def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert sum(counts.values()) == 10
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
     c = Circuit(2, 2)
@@ -1130,7 +1130,7 @@ def test_available_devices(ibm_provider: IBMProvider) -> None:
     assert len(backend_info_list) > 0
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_backendinfo_serialization1(
     manila_emulator_backend: IBMQEmulatorBackend,
@@ -1185,7 +1185,7 @@ def test_sim_qubit_order() -> None:
     assert np.isclose(abs(s[2]), 1.0)
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_requrired_predicates(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     # https://github.com/CQCL/pytket-qiskit/issues/93

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1200,6 +1200,7 @@ def test_requrired_predicates(manila_emulator_backend: IBMQEmulatorBackend) -> N
             in str(errorinfo)
         )
 
+
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ecr_gate_compilation(ibm_sherbrooke_backend: IBMQBackend) -> None:

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1199,3 +1199,30 @@ def test_requrired_predicates(manila_emulator_backend: IBMQEmulatorBackend) -> N
             + "not satisfy MaxNQubitsPredicate(5)"
             in str(errorinfo)
         )
+
+
+@pytest.mark.skipif(skip_remote_tests, reason=REASON)
+def test_ecr_gate_compilation(ibm_sherbrooke_backend: IBMQBackend) -> None:
+    # circuit for an un-routed GHZ state
+    circ = (
+        Circuit(7)
+        .H(0)
+        .CX(0, 1)
+        .CX(0, 2)
+        .CX(0, 3)
+        .CX(0, 4)
+        .CX(0, 5)
+        .CX(0, 6)
+        .measure_all()
+    )
+    for optimisation_level in range(3):
+        compiled_circ = ibm_sherbrooke_backend.get_compiled_circuit(
+            circ, optimisation_level
+        )
+        assert ibm_sherbrooke_backend.backend_info.gate_set >= {
+            OpType.X,
+            OpType.SX,
+            OpType.Rz,
+            OpType.ECR,
+        }
+        assert ibm_sherbrooke_backend.valid_circuit(compiled_circ)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1122,7 +1122,6 @@ def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
 def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
     c = Circuit(2, 2)
     c.H(0).SX(1).CX(0, 1).measure_all()
-    print(simulator_stabilizer_backend._primitive_gates)
     c = simulator_stabilizer_backend.get_compiled_circuit(c, 0)
     h = simulator_stabilizer_backend.process_circuit(c, n_shots=10)
     assert sum(simulator_stabilizer_backend.get_result(h).get_counts().values()) == 10

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1200,7 +1200,7 @@ def test_requrired_predicates(manila_emulator_backend: IBMQEmulatorBackend) -> N
             in str(errorinfo)
         )
 
-
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ecr_gate_compilation(ibm_sherbrooke_backend: IBMQBackend) -> None:
     # circuit for an un-routed GHZ state

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -195,7 +195,7 @@ def test_noise(manila_backend: IBMQBackend) -> None:
     assert shots.shape == (10, 4)
 
 
-@pytest.mark.flaky(reruns=3, rerun_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_process_characterisation(manila_backend: IBMQBackend) -> None:
 
@@ -445,7 +445,7 @@ def test_nshots_batching(manila_backend: IBMQBackend) -> None:
         # ensure shared backend is reset for other tests
         backend._MACHINE_DEBUG = False
 
-@pytest.mark.flaky(reruns=3, rerun_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_nshots(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     for b in [AerBackend(), manila_emulator_backend]:
@@ -671,7 +671,7 @@ def test_operator() -> None:
 
 
 # TKET-1432 this was either too slow or consumed too much memory when bugged
-@pytest.mark.flaky(reruns=3, rerun_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_expectation_bug() -> None:
     backend = AerStateBackend()
     # backend.compile_circuit(circuit)
@@ -807,7 +807,7 @@ def test_operator_expectation_value() -> None:
     e = AerBackend().get_operator_expectation_value(c1, op)
     assert np.isclose(e, 1.0)
 
-@pytest.mark.flaky(reruns=3, rerun_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ibmq_emulator(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert manila_emulator_backend._noise_model is not None
@@ -1084,7 +1084,7 @@ def test_postprocess(lima_backend: IBMQBackend) -> None:
     assert all(ppcmd.op.type == OpType.ClassicalTransform for ppcmd in ppcmds)
     b.cancel(h)
 
-@pytest.mark.flaky(reruns=3, rerun_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert manila_emulator_backend.supports_contextual_optimisation
@@ -1101,7 +1101,7 @@ def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert sum(counts.values()) == 10
 
 
-@pytest.mark.flaky(reruns=3, rerun_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
     c = Circuit(2, 2)
@@ -1126,7 +1126,7 @@ def test_available_devices(ibm_provider: IBMProvider) -> None:
     backend_info_list = IBMQBackend.available_devices()
     assert len(backend_info_list) > 0
 
-@pytest.mark.flaky(reruns=3, rerun_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_backendinfo_serialization1(
     manila_emulator_backend: IBMQEmulatorBackend,
@@ -1180,7 +1180,7 @@ def test_sim_qubit_order() -> None:
     s = backend.run_circuit(circ).get_state()
     assert np.isclose(abs(s[2]), 1.0)
 
-@pytest.mark.flaky(reruns=3, rerun_delay=2)
+@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_requrired_predicates(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     # https://github.com/CQCL/pytket-qiskit/issues/93

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1204,6 +1204,12 @@ def test_requrired_predicates(manila_emulator_backend: IBMQEmulatorBackend) -> N
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ecr_gate_compilation(ibm_sherbrooke_backend: IBMQBackend) -> None:
+    assert ibm_sherbrooke_backend.backend_info.gate_set >= {
+        OpType.X,
+        OpType.SX,
+        OpType.Rz,
+        OpType.ECR,
+    }
     # circuit for an un-routed GHZ state
     circ = (
         Circuit(7)
@@ -1220,10 +1226,4 @@ def test_ecr_gate_compilation(ibm_sherbrooke_backend: IBMQBackend) -> None:
         compiled_circ = ibm_sherbrooke_backend.get_compiled_circuit(
             circ, optimisation_level
         )
-        assert ibm_sherbrooke_backend.backend_info.gate_set >= {
-            OpType.X,
-            OpType.SX,
-            OpType.Rz,
-            OpType.ECR,
-        }
         assert ibm_sherbrooke_backend.valid_circuit(compiled_circ)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -445,6 +445,7 @@ def test_nshots_batching(manila_backend: IBMQBackend) -> None:
         # ensure shared backend is reset for other tests
         backend._MACHINE_DEBUG = False
 
+
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_nshots(manila_emulator_backend: IBMQEmulatorBackend) -> None:
@@ -807,6 +808,7 @@ def test_operator_expectation_value() -> None:
     e = AerBackend().get_operator_expectation_value(c1, op)
     assert np.isclose(e, 1.0)
 
+
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ibmq_emulator(manila_emulator_backend: IBMQEmulatorBackend) -> None:
@@ -1084,6 +1086,7 @@ def test_postprocess(lima_backend: IBMQBackend) -> None:
     assert all(ppcmd.op.type == OpType.ClassicalTransform for ppcmd in ppcmds)
     b.cancel(h)
 
+
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
@@ -1125,6 +1128,7 @@ def test_available_devices(ibm_provider: IBMProvider) -> None:
 
     backend_info_list = IBMQBackend.available_devices()
     assert len(backend_info_list) > 0
+
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
@@ -1179,6 +1183,7 @@ def test_sim_qubit_order() -> None:
     circ.X(Qubit("a", 0))
     s = backend.run_circuit(circ).get_state()
     assert np.isclose(abs(s[2]), 1.0)
+
 
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -195,7 +195,7 @@ def test_noise(manila_backend: IBMQBackend) -> None:
     assert shots.shape == (10, 4)
 
 
-@pytest.mark.timeout(None)
+@pytest.mark.flaky(reruns=3, rerun_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_process_characterisation(manila_backend: IBMQBackend) -> None:
 
@@ -671,7 +671,7 @@ def test_operator() -> None:
 
 
 # TKET-1432 this was either too slow or consumed too much memory when bugged
-@pytest.mark.timeout(10)
+@pytest.mark.flaky(reruns=3, rerun_delay=2)
 def test_expectation_bug() -> None:
     backend = AerStateBackend()
     # backend.compile_circuit(circuit)
@@ -1101,7 +1101,7 @@ def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
     assert sum(counts.values()) == 10
 
 
-@pytest.mark.timeout(None)
+@pytest.mark.flaky(reruns=3, rerun_delay=2)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
     c = Circuit(2, 2)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1122,6 +1122,7 @@ def test_postprocess_emu(manila_emulator_backend: IBMQEmulatorBackend) -> None:
 def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
     c = Circuit(2, 2)
     c.H(0).SX(1).CX(0, 1).measure_all()
+    print(simulator_stabilizer_backend._primitive_gates)
     c = simulator_stabilizer_backend.get_compiled_circuit(c, 0)
     h = simulator_stabilizer_backend.process_circuit(c, n_shots=10)
     assert sum(simulator_stabilizer_backend.get_result(h).get_counts().values()) == 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,3 +100,12 @@ def ibm_provider() -> IBMProvider:
     except:
         token = os.getenv("PYTKET_REMOTE_QISKIT_TOKEN")
         return IBMProvider(token=token, instance="ibm-q/open/main", overwrite=True)
+
+
+@pytest.fixture(scope="module")
+def ibm_sherbrooke_backend() -> IBMQBackend:
+    return IBMQBackend(
+        "ibm_sherbrooke",
+        monitor=False,
+        token=os.getenv("PYTKET_REMOTE_QISKIT_TOKEN"),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,7 @@ def ibm_provider() -> IBMProvider:
 @pytest.fixture(scope="module")
 def ibm_sherbrooke_backend() -> IBMQBackend:
     return IBMQBackend(
-        "ibm_sherbrooke",
+        backend_name="ibm_sherbrooke",
         monitor=False,
         token=os.getenv("PYTKET_REMOTE_QISKIT_TOKEN"),
     )

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,4 +1,4 @@
 pytest
-pytest-timeout ~= 1.4.2
+pytest-rerunfailures
 hypothesis
 requests_mock


### PR DESCRIPTION
Relates to the issue #112 

Newer IBM devices support the [ECR gate](https://qiskit.org/documentation/stubs/qiskit.circuit.library.ECRGate.html) instead of the CX gate.

As a workaround I've defined a `RebaseCustom` to {X, SX, Rz, ECR} rather than defining a new decomposition for `auto_rebase_pass` in TKET itself

The CX replacement I've used is the following


![Screenshot 2023-06-01 at 15 56 38](https://github.com/CQCL/pytket-qiskit/assets/93673602/37e24064-8324-47df-96db-74b9b5327ac0)

* I've created a new `IBMBackend._primitive_gates` attribute which is either {X, SX, Rz, CX} , {X, SX, Rz, ECR} or the value returned by the `_tk_gateset` function depending on which gates get reported back from the API. I have also removed the `IBMQBackend._standard_gates` attribute.


* Prior to this PR we did a check if the Backend supported {X, SX, Rz, CX} in the default compilation. I've removed this as I wwant the rebase to be applied in both cases. Maybe it'd make sense to check the `GateSetPredicate` for `optimisation_level=0` instead and if its satisfied then just skip the rebase.

I've also made use of the `pytest-rerunfailures` package to rerun failing tests so hopefully we won't keep getting CI failures for transient issues. This is an alternative to removing the timeout altogether which results in very long execution times for CI jobs.

```python
@pytest.mark.flaky(reruns=3, reruns_delay=10)
@pytest.mark.skipif(skip_remote_tests, reason=REASON)
def test_nshots(manila_emulator_backend: IBMQEmulatorBackend) -> None:
    for b in [AerBackend(), manila_emulator_backend]:
        circuit = Circuit(1).X(0)
        circuit.measure_all()
        n_shots = [1, 2, 3]
        results = b.get_results(b.process_circuits([circuit] * 3, n_shots=n_shots))
        assert [sum(r.get_counts().values()) for r in results] == n_shots
```


