### PR TITLE
Fix/available devices

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -88,9 +88,10 @@ To see which devices you can access you can use the ``available_devices`` method
     from pytket.extensions.qiskit import IBMQBackend
     from qiskit_ibm_provider import IBMProvider
 
-    ibm_provider = IBMProvider()
+    ibm_provider = IBMProvider(instance=f"{hub}/{group}/{project}")
     backend = IBMQBackend("ibmq_belem") # Initialise backend for an IBM device
-    backend.available_devices(instance=instance=f"{hub}/{group}/{project}", provider=ibm_provider) 
+    backendinfo_list = backend.available_devices(instance=f"{hub}/{group}/{project}", provider=ibm_provider) 
+    print([backend.device_name for backend in backendinfo_list])
 
 
 Backends Available Through pytket-qiskit

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -316,11 +316,14 @@ class IBMQBackend(Backend):
 
     @classmethod
     def available_devices(cls, **kwargs: Any) -> List[BackendInfo]:
-        provider = kwargs.get("provider")
+        provider: Optional["IBMProvider"] = kwargs.get("provider")
         if provider is None:
             if kwargs.get("instance") is not None:
-                provider = cls._get_provider(kwargs.get("instance"), None)
-            provider = IBMProvider()
+                provider = cls._get_provider(
+                    instance=kwargs.get("instance"), qiskit_config=None
+                )
+            else:
+                provider = IBMProvider()
 
         backend_info_list = [
             cls._get_backend_info(backend) for backend in provider.backends()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1123,6 +1123,9 @@ def test_available_devices(ibm_provider: IBMProvider) -> None:
     backend_info_list = IBMQBackend.available_devices(instance="ibm-q/open/main")
     assert len(backend_info_list) > 0
 
+    # Check consistency with pytket-qiskit and qiskit provider
+    assert len(backend_info_list) == len(ibm_provider.backends())
+
     backend_info_list = IBMQBackend.available_devices(provider=ibm_provider)
     assert len(backend_info_list) > 0
 


### PR DESCRIPTION
This PR fixes a bug with `IBMQBackend.available_devices()` introduced in https://github.com/CQCL/pytket-qiskit/pull/116

basically the version of with the instance string `IBMProvider(instance="ibm-q/open/main")` was always being overwritten by `IBMProvider()` due to the fact that an else statement was missing.