### PR TITLE
Fix conversion of controllled gates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,7 +5,7 @@ Unreleased
 ----------
 
 * Fix conversion of qiskit `UnitaryGate` to and from pytket (up to 3 qubits).
-* Fix handling of qiskit controlled gates the :py:meth:`qiskit_to_tk` converter.
+* Fix handling of qiskit controlled gates in the :py:meth:`qiskit_to_tk` converter.
 * Handle CCZ and CSX gates in circuit converters.
 
 0.40.0 (June 2023)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Unreleased
 ----------
 
 * Fix conversion of qiskit `UnitaryGate` to and from pytket (up to 3 qubits).
+* Fix handling of qiskit controlled gates the :py:meth:`qiskit_to_tk` converter.
+* Handle CCZ and CSX gates in circuit converters.
 
 0.40.0 (June 2023)
 ------------------

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -352,13 +352,18 @@ class CircuitBuilder:
                 pass
             self.add_xs(num_ctrl_qubits, ctrl_state, qargs)
             optype = None
-            if type(instr) == ControlledGate:
+            if isinstance(instr, ControlledGate):
                 if type(instr.base_gate) == qiskit_gates.RYGate:
                     optype = OpType.CnRy
                 elif type(instr.base_gate) == qiskit_gates.YGate:
                     optype = OpType.CnY
                 elif type(instr.base_gate) == qiskit_gates.ZGate:
                     optype = OpType.CnZ
+                elif (
+                    type(instr.base_gate) in _known_qiskit_gate
+                    and type(instr) in _known_qiskit_gate
+                ):
+                    optype = _known_qiskit_gate[type(instr)]
                 else:
                     if type(instr.base_gate) in _known_qiskit_gate:
                         optype = OpType.QControlBox  # QControlBox case handled below

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -355,18 +355,12 @@ class CircuitBuilder:
             if isinstance(instr, ControlledGate):
                 if type(instr) in _known_qiskit_gate:
                     optype = _known_qiskit_gate[type(instr)]
-                    pass
                 elif type(instr.base_gate) == qiskit_gates.RYGate:
                     optype = OpType.CnRy
                 elif type(instr.base_gate) == qiskit_gates.YGate:
                     optype = OpType.CnY
                 elif type(instr.base_gate) == qiskit_gates.ZGate:
                     optype = OpType.CnZ
-                elif (
-                    type(instr.base_gate) in _known_qiskit_gate
-                    and type(instr) in _known_qiskit_gate
-                ):
-                    optype = _known_qiskit_gate[type(instr)]
                 else:
                     if type(instr.base_gate) in _known_qiskit_gate:
                         optype = OpType.QControlBox  # QControlBox case handled below

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -353,7 +353,10 @@ class CircuitBuilder:
             self.add_xs(num_ctrl_qubits, ctrl_state, qargs)
             optype = None
             if isinstance(instr, ControlledGate):
-                if type(instr.base_gate) == qiskit_gates.RYGate:
+                if type(instr) in _known_qiskit_gate:
+                    optype = _known_qiskit_gate[type(instr)]
+                    pass
+                elif type(instr.base_gate) == qiskit_gates.RYGate:
                     optype = OpType.CnRy
                 elif type(instr.base_gate) == qiskit_gates.YGate:
                     optype = OpType.CnY

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -354,8 +354,8 @@ class CircuitBuilder:
             optype = None
             if isinstance(instr, ControlledGate):
                 if type(instr) in _known_qiskit_gate:
-                # First we check that the gate isn't in _known_qiskit_gate
-                # this avoids CZ being converted to CnZ
+                    # First we check that the gate isn't in _known_qiskit_gate
+                    # this avoids CZ being converted to CnZ
                     optype = _known_qiskit_gate[type(instr)]
                 elif type(instr.base_gate) == qiskit_gates.RYGate:
                     optype = OpType.CnRy

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -354,6 +354,8 @@ class CircuitBuilder:
             optype = None
             if isinstance(instr, ControlledGate):
                 if type(instr) in _known_qiskit_gate:
+                # First we check that the gate isn't in _known_qiskit_gate
+                # this avoids CZ being converted to CnZ
                     optype = _known_qiskit_gate[type(instr)]
                 elif type(instr.base_gate) == qiskit_gates.RYGate:
                     optype = OpType.CnRy

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -354,7 +354,7 @@ class CircuitBuilder:
             optype = None
             if isinstance(instr, ControlledGate):
                 if type(instr) in _known_qiskit_gate:
-                    # First we check that the gate isn't in _known_qiskit_gate
+                    # First we check if the gate is in _known_qiskit_gate
                     # this avoids CZ being converted to CnZ
                     optype = _known_qiskit_gate[type(instr)]
                 elif type(instr.base_gate) == qiskit_gates.RYGate:
@@ -383,8 +383,8 @@ class CircuitBuilder:
                 params = [param_to_tk(p) for p in instr.base_gate.params]
                 n_base_qubits = instr.base_gate.num_qubits
                 sub_circ = Circuit(n_base_qubits)
-                # Use U for the name of the base gate in QControlBox
-                sub_circ.name = "U"
+                # use base gate name for the CircBox (shows in renderer)
+                sub_circ.name = instr.base_gate.name.capitalize()
                 sub_circ.add_gate(base_tket_gate, params, list(range(n_base_qubits)))
                 c_box = CircBox(sub_circ)
                 q_ctrl_box = QControlBox(c_box, instr.num_ctrl_qubits)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -383,7 +383,7 @@ class CircuitBuilder:
                 params = [param_to_tk(p) for p in instr.base_gate.params]
                 n_base_qubits = instr.base_gate.num_qubits
                 sub_circ = Circuit(n_base_qubits)
-                # use base gate name for the CircBox (shows in renderer)
+                # Use U for the name of the base gate in QControlBox
                 sub_circ.name = "U"
                 sub_circ.add_gate(base_tket_gate, params, list(range(n_base_qubits)))
                 c_box = CircBox(sub_circ)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -137,6 +137,7 @@ _qiskit_gates_other = {
     qiskit_gates.C3XGate: OpType.CnX,
     qiskit_gates.C4XGate: OpType.CnX,
     qiskit_gates.CCXGate: OpType.CCX,
+    qiskit_gates.CCZGate: OpType.CnZ,
     qiskit_gates.CSwapGate: OpType.CSWAP,
     # Multi-controlled gates (qiskit expects a list of controls followed by the target):
     qiskit_gates.MCXGate: OpType.CnX,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -122,6 +122,7 @@ _qiskit_gates_2q = {
     qiskit_gates.CU1Gate: OpType.CU1,
     qiskit_gates.CU3Gate: OpType.CU3,
     qiskit_gates.CXGate: OpType.CX,
+    qiskit_gates.CSXGate: OpType.CSX,
     qiskit_gates.CYGate: OpType.CY,
     qiskit_gates.CZGate: OpType.CZ,
     qiskit_gates.ECRGate: OpType.ECR,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -384,7 +384,7 @@ class CircuitBuilder:
                 n_base_qubits = instr.base_gate.num_qubits
                 sub_circ = Circuit(n_base_qubits)
                 # use base gate name for the CircBox (shows in renderer)
-                sub_circ.name = instr.base_gate.name.capitalize()
+                sub_circ.name = "U"
                 sub_circ.add_gate(base_tket_gate, params, list(range(n_base_qubits)))
                 c_box = CircBox(sub_circ)
                 q_ctrl_box = QControlBox(c_box, instr.num_ctrl_qubits)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -977,7 +977,8 @@ def test_csx_conversion() -> None:
     qc_csx.append(qiskit_gates.CSXGate(), [0, 1])
     qc_csx.append(qiskit_gates.CSXGate(), [1, 0])
     converted_tkc = qiskit_to_tk(qc_csx)
-    assert converted_tkc.n_gates_of_type(OpType.CSX) == converted_tkc.n_gates == 2
+    assert converted_tkc.n_gates == 2
+    assert converted_tkc.n_gates_of_type(OpType.CSX) == 2
     u1 = converted_tkc.get_unitary()
     new_tkc_csx = Circuit(2)
     new_tkc_csx.add_gate(OpType.CSX, [0, 1]).add_gate(OpType.CSX, [1, 0])
@@ -985,6 +986,10 @@ def test_csx_conversion() -> None:
     assert compare_unitaries(u1, u2)
     converted_qc = tk_to_qiskit(new_tkc_csx)
     assert converted_qc.count_ops()["csx"] == 2
+    qc_c3sx = QuantumCircuit(4)
+    qc_c3sx.append(qiskit_gates.C3SXGate(), [0, 1, 2, 3])
+    tkc_c3sx = qiskit_to_tk(qc_c3sx)
+    assert tkc_c3sx.n_gates == tkc_c3sx.n_gates_of_type(OpType.QControlBox) == 1
 
 
 def test_CS_and_CSdg() -> None:

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -947,7 +947,7 @@ def test_conversion_to_tket_with_and_without_resets() -> None:
     qiskit_state = _get_qiskit_statevector(decomp_qc)
     assert compare_statevectors(tkc_sv, qiskit_state)
 
-    
+
 def test_unitary_gate() -> None:
     # https://github.com/CQCL/pytket-qiskit/issues/122
     qkc = QuantumCircuit(3)
@@ -961,8 +961,8 @@ def test_unitary_gate() -> None:
     assert cmds[0].op.type == OpType.Unitary1qBox
     assert cmds[1].op.type == OpType.Unitary2qBox
     assert cmds[2].op.type == OpType.Unitary3qBox
-    
-    
+
+
 def test_ccz_conversion() -> None:
     qc_ccz = QuantumCircuit(4)
     qc_ccz.append(qiskit_gates.CCZGate(), [0, 1, 2])
@@ -995,4 +995,3 @@ def test_CS_and_CSdg() -> None:
     qiskit_qc.append(qiskit_gates.CSdgGate(), [1, 0])
     tkc = qiskit_to_tk(qiskit_qc)
     assert tkc.n_gates_of_type(OpType.QControlBox) == 4
-

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -976,7 +976,6 @@ def test_ccz_conversion() -> None:
     assert compare_unitaries(tkc_ccz.get_unitary(), tkc_ccz2.get_unitary())
 
 
-
 def test_csx_conversion() -> None:
     qc_csx = QuantumCircuit(2)
     qc_csx.append(qiskit_gates.CSXGate(), [0, 1])

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -970,6 +970,11 @@ def test_ccz_conversion() -> None:
     tkc_ccz = qiskit_to_tk(qc_ccz)
     assert tkc_ccz.n_gates_of_type(OpType.CnZ) == tkc_ccz.n_gates == 2
     # bidirectional CnZ conversion already supported
+    qc_ccz2 = tk_to_qiskit(tkc_ccz)
+    assert qc_ccz2.count_ops()["ccz"] == 2
+    tkc_ccz2 = qiskit_to_tk(qc_ccz2)
+    assert compare_unitaries(tkc_ccz.get_unitary(), tkc_ccz2.get_unitary())
+
 
 
 def test_csx_conversion() -> None:


### PR DESCRIPTION
Adding the ability to handle the controlled gates mentioned in https://github.com/CQCL/pytket-qiskit/issues/88.
CCZ and CSX are both easily handled.

Also fixed the issue with Controlled gates not being handled correctly as `QControlBox`(es) in https://github.com/CQCL/pytket-qiskit/issues/134 .