### PR TITLE
Improve Code Snippets: Add Import Statement and Clarify String Usage

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -83,8 +83,8 @@ locally without saving the token in pytket config:
     from qiskit_ibm_provider import IBMProvider
     from qiskit_ibm_runtime import QiskitRuntimeService
 
-    IBMProvider.save_account(token=ibm_token)
-    QiskitRuntimeService.save_account(channel="ibm_quantum", token=ibm_token)
+    IBMProvider.save_account(token="ibm_token")
+    QiskitRuntimeService.save_account(channel="ibm_quantum", token="ibm_token")
 
 To see which devices you can access you can use the ``available_devices`` method on the :py:class:`IBMQBackend` or :py:class:`IBMQEmulatorBackend`. Note that it is possible to pass optional ``instance`` and ``provider`` arguments to this method. This allows you to see which devices are accessible through your IBM hub.
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -24,6 +24,7 @@ An example using the shots-based :py:class:`AerBackend` simulator is shown below
 ::
 
   from pytket.extensions.qiskit import AerBackend
+  from pytket import Circuit
 
   backend = AerBackend()
   circ = Circuit(2).H(0).CX(0, 1).measure_all()
@@ -60,7 +61,7 @@ Once you have created an account you can obtain an API token which you can use t
 
     from pytket.extensions.qiskit import set_ibmq_config
     
-    set_ibmq_config(ibmq_api_token=ibm_token)
+    set_ibmq_config(ibmq_api_token="ibm_token")
 
 After saving your credentials you can access ``pytket-qiskit`` backend repeatedly without having to re-initialise your credentials.
 
@@ -70,7 +71,7 @@ If you are a member of an IBM hub then you can add this information to ``set_ibm
 
     from pytket.extensions.qiskit import set_ibmq_config
 
-    set_ibmq_config(ibmq_api_token=ibm_token, instance=f"{hub}/{group}/{project}")
+    set_ibmq_config(ibmq_api_token="ibm_token", instance=f"{'hub'}/{'group'}/{'project'}")
 
 Alternatively you can use the following qiskit commands to save your credentials
 locally without saving the token in pytket config:
@@ -92,7 +93,7 @@ To see which devices you can access you can use the ``available_devices`` method
     from pytket.extensions.qiskit import IBMQBackend
     from qiskit_ibm_provider import IBMProvider
 
-    my_instance=f"{hub}/{group}/{project}"
+    my_instance=f"{'hub'}/{'group'}/{'project'}"
     ibm_provider = IBMProvider(instance=my_instance)
     backend = IBMQBackend("ibmq_belem") # Initialise backend for an IBM device
     backendinfo_list = backend.available_devices(instance=my_instance, provider=ibm_provider) 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -61,7 +61,7 @@ Once you have created an account you can obtain an API token which you can use t
 
     from pytket.extensions.qiskit import set_ibmq_config
     
-    set_ibmq_config(ibmq_api_token="ibm_token")
+    set_ibmq_config(ibmq_api_token='ibm_token')
 
 After saving your credentials you can access ``pytket-qiskit`` backend repeatedly without having to re-initialise your credentials.
 
@@ -71,7 +71,7 @@ If you are a member of an IBM hub then you can add this information to ``set_ibm
 
     from pytket.extensions.qiskit import set_ibmq_config
 
-    set_ibmq_config(ibmq_api_token="ibm_token", instance=f"{'hub'}/{'group'}/{'project'}")
+    set_ibmq_config(ibmq_api_token='ibm_token', instance=f"{'hub'}/{'group'}/{'project'}")
 
 Alternatively you can use the following qiskit commands to save your credentials
 locally without saving the token in pytket config:
@@ -83,8 +83,8 @@ locally without saving the token in pytket config:
     from qiskit_ibm_provider import IBMProvider
     from qiskit_ibm_runtime import QiskitRuntimeService
 
-    IBMProvider.save_account(token="ibm_token")
-    QiskitRuntimeService.save_account(channel="ibm_quantum", token="ibm_token")
+    IBMProvider.save_account(token='ibm_token')
+    QiskitRuntimeService.save_account(channel="ibm_quantum", token='ibm_token')
 
 To see which devices you can access you can use the ``available_devices`` method on the :py:class:`IBMQBackend` or :py:class:`IBMQEmulatorBackend`. Note that it is possible to pass optional ``instance`` and ``provider`` arguments to this method. This allows you to see which devices are accessible through your IBM hub.
 


### PR DESCRIPTION
These are suggested changes for a user who wants to simply copy the following code snippets and run them

suggest adding line 27:
`from pytket import Circuit`
since one gets _NameError: name 'Circuit' is not defined_ after running `pip install pytket-qiskit` and then wanting to try out this code snippet.

suggest adding `' '` around `ibm_token` in `set_ibmq_config(ibmq_api_token=ibm_token)`
because without it, one gets a _NameError: name '12345...' is not defined_ after simply inserting their copied API token i.e. `12345...` from IBM Q.

similar adding `' '` around `ibm_token` and adding `' '` around `hub`, `group`, `project`  in `set_ibmq_config(ibmq_api_token=ibm_token, instance=f"{hub}/{group}/{project}")` 
i.e one gets an error message without the `' '` for the entries inside the `instance` call.

and suggestions to include `' '` around `ibm_token` in
`IBMProvider.save_account(token=ibm_token)`
`QiskitRuntimeService.save_account(channel="ibm_quantum", token=ibm_token)`
and to include `' '` around  `hub`, `group`, `project`  in 
`my_instance=f"{hub}/{group}/{project}"`
follow from the above.





