### PR TITLE
Improve error message for failed `qiskit_to_tk` conversion

### DIFF
--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -379,7 +379,7 @@ class CircuitBuilder:
                 except KeyError:
                     raise NotImplementedError(
                         f"Conversion of qiskit's {instr.name} instruction is "
-                        + "currently unsupported by qiskit_to_tk. Perhaps try "
+                        + "currently unsupported by qiskit_to_tk. Consider "
                         + "using QuantumCircuit.decompose() before attempting "
                         + "conversion."
                     )

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -376,13 +376,13 @@ class CircuitBuilder:
             else:
                 try:
                     optype = _known_qiskit_gate[type(instr)]
-                except KeyError as keyerr:
+                except KeyError:
                     raise NotImplementedError(
                         f"Conversion of qiskit's {instr.name} instruction is "
                         + "currently unsupported by qiskit_to_tk. Perhaps try "
                         + "using QuantumCircuit.decompose() before attempting "
                         + "conversion."
-                    ) from keyerr
+                    )
             qubits = [self.qbmap[qbit] for qbit in qargs]
             bits = [self.cbmap[bit] for bit in cargs]
 
@@ -656,6 +656,17 @@ def append_tk_command_to_qiskit(
             width = op.width
             value = op.value
         regname = args[0].reg_name
+        if len(cregmap[regname]) != width:
+            raise NotImplementedError("OpenQASM conditions must be an entire register")
+        for i, a in enumerate(args[:width]):
+            if a.reg_name != regname:
+                raise NotImplementedError(
+                    "OpenQASM conditions can only use a single register"
+                )
+            if a.index != [i]:
+                raise NotImplementedError(
+                    "OpenQASM conditions must be an entire register in order"
+                )
         instruction = append_tk_command_to_qiskit(
             op.op, args[width:], qcirc, qregmap, cregmap, symb_map, range_preds
         )

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -376,13 +376,13 @@ class CircuitBuilder:
             else:
                 try:
                     optype = _known_qiskit_gate[type(instr)]
-                except KeyError:
+                except KeyError as keyerr:
                     raise NotImplementedError(
                         f"Conversion of qiskit's {instr.name} instruction is "
                         + "currently unsupported by qiskit_to_tk. Perhaps try "
                         + "using QuantumCircuit.decompose() before attempting "
                         + "conversion."
-                    )
+                    ) from keyerr
             qubits = [self.qbmap[qbit] for qbit in qargs]
             bits = [self.cbmap[bit] for bit in cargs]
 
@@ -656,17 +656,6 @@ def append_tk_command_to_qiskit(
             width = op.width
             value = op.value
         regname = args[0].reg_name
-        if len(cregmap[regname]) != width:
-            raise NotImplementedError("OpenQASM conditions must be an entire register")
-        for i, a in enumerate(args[:width]):
-            if a.reg_name != regname:
-                raise NotImplementedError(
-                    "OpenQASM conditions can only use a single register"
-                )
-            if a.index != [i]:
-                raise NotImplementedError(
-                    "OpenQASM conditions must be an entire register in order"
-                )
         instruction = append_tk_command_to_qiskit(
             op.op, args[width:], qcirc, qregmap, cregmap, symb_map, range_preds
         )

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -374,7 +374,15 @@ class CircuitBuilder:
             elif type(instr) in [PauliEvolutionGate, UnitaryGate]:
                 pass  # Special handling below
             else:
-                optype = _known_qiskit_gate[type(instr)]
+                try:
+                    optype = _known_qiskit_gate[type(instr)]
+                except KeyError:
+                    raise NotImplementedError(
+                        f"Conversion of qiskit's {instr.name} instruction is "
+                        + "currently unsupported by qiskit_to_tk. Perhaps try "
+                        + "using QuantumCircuit.decompose() before attempting "
+                        + "conversion."
+                    )
             qubits = [self.qbmap[qbit] for qbit in qargs]
             bits = [self.cbmap[bit] for bit in cargs]
 

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -28,7 +28,7 @@ from qiskit.opflow import PauliOp, PauliSumOp, PauliTrotterEvolution, Suzuki  # 
 from qiskit.opflow.primitive_ops import PauliSumOp  # type: ignore
 from qiskit.quantum_info import Pauli  # type: ignore
 from qiskit.transpiler import PassManager  # type: ignore
-from qiskit.circuit.library import RYGate, MCMT  # type: ignore
+from qiskit.circuit.library import RYGate, MCMT, XXPlusYYGate  # type: ignore
 import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore
 from qiskit.circuit import Parameter  # type: ignore
 from qiskit_aer import Aer  # type: ignore
@@ -1004,3 +1004,12 @@ def test_CS_and_CSdg() -> None:
     qiskit_qc.append(qiskit_gates.CSdgGate(), [1, 0])
     tkc = qiskit_to_tk(qiskit_qc)
     assert tkc.n_gates_of_type(OpType.QControlBox) == 4
+
+
+def test_failed_conversion_error() -> None:
+    qc = QuantumCircuit(2)
+    qc.append(XXPlusYYGate(0.1), [0, 1])  # add unsupported gate
+    with pytest.raises(
+        NotImplementedError, match=r"Conversion of qiskit's xx_plus_yy instruction"
+    ):
+        qiskit_to_tk(qc)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -400,27 +400,6 @@ def test_conditions() -> None:
     # conversion loses rangepredicates so equality comparison not valid
 
 
-def test_condition_errors() -> None:
-    with pytest.raises(Exception) as errorinfo:
-        c = Circuit(2, 2)
-        c.X(0, condition_bits=[0], condition_value=1)
-        tk_to_qiskit(c)
-    assert "OpenQASM conditions must be an entire register" in str(errorinfo.value)
-    with pytest.raises(Exception) as errorinfo:
-        c = Circuit(2, 2)
-        b = c.add_c_register("b", 2)
-        c.X(Qubit(0), condition_bits=[b[0], Bit(0)], condition_value=1)
-        tk_to_qiskit(c)
-    assert "OpenQASM conditions can only use a single register" in str(errorinfo.value)
-    with pytest.raises(Exception) as errorinfo:
-        c = Circuit(2, 2)
-        c.X(0, condition_bits=[1, 0], condition_value=1)
-        tk_to_qiskit(c)
-    assert "OpenQASM conditions must be an entire register in order" in str(
-        errorinfo.value
-    )
-
-
 def test_correction() -> None:
     checked_x = Circuit(2, 1)
     checked_x.CX(0, 1)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -400,6 +400,27 @@ def test_conditions() -> None:
     # conversion loses rangepredicates so equality comparison not valid
 
 
+def test_condition_errors() -> None:
+    with pytest.raises(Exception) as errorinfo:
+        c = Circuit(2, 2)
+        c.X(0, condition_bits=[0], condition_value=1)
+        tk_to_qiskit(c)
+    assert "OpenQASM conditions must be an entire register" in str(errorinfo.value)
+    with pytest.raises(Exception) as errorinfo:
+        c = Circuit(2, 2)
+        b = c.add_c_register("b", 2)
+        c.X(Qubit(0), condition_bits=[b[0], Bit(0)], condition_value=1)
+        tk_to_qiskit(c)
+    assert "OpenQASM conditions can only use a single register" in str(errorinfo.value)
+    with pytest.raises(Exception) as errorinfo:
+        c = Circuit(2, 2)
+        c.X(0, condition_bits=[1, 0], condition_value=1)
+        tk_to_qiskit(c)
+    assert "OpenQASM conditions must be an entire register in order" in str(
+        errorinfo.value
+    )
+
+
 def test_correction() -> None:
     checked_x = Circuit(2, 1)
     checked_x.CX(0, 1)


### PR DESCRIPTION
Small PR to imporve the error message for failed `qiskit_to_tk` conversion adressing https://github.com/CQCL/pytket-qiskit/issues/150

This snippet now gives the following error message for the unsupported gate

```python
from qiskit import QuantumCircuit
from qiskit.circuit.library import XXPlusYYGate
from pytket.extensions.qiskit import qiskit_to_tk

qc = QuantumCircuit(2)
qc.append(XXPlusYYGate(0.1), [0, 1]) # add unsupported gate

tkc = qiskit_to_tk(qc)
```

![Screenshot 2023-08-11 at 11 02 48](https://github.com/CQCL/pytket-qiskit/assets/93673602/ecd58ac9-f4e1-404e-be3f-b845df3cf888)


Note: The two reverted commits correspond to an attempted fix of https://github.com/CQCL/pytket-qiskit/issues/43. However I realised this was slightly more involved than expected so its probably best adressed in a separate PR.