### PR TITLE
Update intro.txt

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -105,7 +105,7 @@ To see which devices you can access you can use the ``available_devices`` method
 
     my_instance=f"{hub}/{group}/{project}"
     ibm_provider = IBMProvider(instance=my_instance)
-    backend = IBMQBackend("ibmq_belem") # Initialise backend for an IBM device
+    backend = IBMQBackend("ibmq_nairobi") # Initialise backend for an IBM device
     backendinfo_list = backend.available_devices(instance=my_instance, provider=ibm_provider) 
     print([backend.device_name for backend in backendinfo_list])
 


### PR DESCRIPTION
The qiskit documentation mentions `ibmq_belem`. That system has now been retired by IBMQ,The following systems have been retired on September 26th: ibmq_lima, ibmq_belem, ibmq_quito, ibmq_manila, and ibmq_jakarta.

So replaced it with the `ibm_nairobi` 