### PR TITLE
Fix `RuntimeError` when converting qiskit instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ obj
 docs/extensions
 .ipynb_checkpoints
 pytket/extensions/qiskit/_metadata.py
+*.ipynb

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -154,7 +154,7 @@ _qiskit_gates_other = {
     # Special types:
     Barrier: OpType.Barrier,
     Instruction: OpType.CircBox,
-    Gate: OpType.CustomGate,
+    Gate: OpType.CircBox,
     Measure: OpType.Measure,
     Reset: OpType.Reset,
     Initialize: OpType.StatePreparationBox,
@@ -476,7 +476,7 @@ class CircuitBuilder:
 
             elif optype == OpType.Barrier:
                 self.tkc.add_barrier(qubits)
-            elif optype in (OpType.CircBox, OpType.CustomGate):
+            elif optype == OpType.CircBox:
                 qregs = (
                     [QuantumRegister(instr.num_qubits, "q")]
                     if instr.num_qubits > 0
@@ -490,17 +490,10 @@ class CircuitBuilder:
                 builder = CircuitBuilder(qregs, cregs)
                 builder.add_qiskit_data(instr.definition)
                 subc = builder.circuit()
-                if optype == OpType.CircBox:
-                    cbox = CircBox(subc)
-                    self.tkc.add_circbox(cbox, qubits + bits, **condition_kwargs)  # type: ignore
-                else:
-                    # warning, this will catch all `Gate` instances
-                    # that were not picked up as a subclass in _known_qiskit_gate
-                    params = [param_to_tk(p) for p in instr.params]
-                    gate_def = CustomGateDef.define(
-                        instr.name, subc, list(subc.free_symbols())
-                    )
-                    self.tkc.add_custom_gate(gate_def, params, qubits + bits)  # type: ignore
+                subc.name = instr.name
+                cbox = CircBox(subc)
+                self.tkc.add_circbox(cbox, qubits + bits, **condition_kwargs)  # type: ignore
+
             elif optype == OpType.CU3 and type(instr) == qiskit_gates.CUGate:
                 if instr.params[-1] == 0:
                     self.tkc.add_gate(
@@ -744,6 +737,7 @@ _protected_tket_gates = (
     _supported_tket_gates
     | _additional_multi_controlled_gates
     | {OpType.Unitary1qBox, OpType.Unitary2qBox, OpType.Unitary3qBox}
+    | {OpType.CustomGate}
 )
 
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -491,8 +491,7 @@ class CircuitBuilder:
                 builder.add_qiskit_data(instr.definition)
                 subc = builder.circuit()
                 subc.name = instr.name
-                cbox = CircBox(subc)
-                self.tkc.add_circbox(cbox, qubits + bits, **condition_kwargs)  # type: ignore
+                self.tkc.add_circbox(CircBox(subc), qubits + bits, **condition_kwargs)  # type: ignore
 
             elif optype == OpType.CU3 and type(instr) == qiskit_gates.CUGate:
                 if instr.params[-1] == 0:

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1032,3 +1032,8 @@ def test_RealAmplitudes_numeric_params() -> None:
     DecomposeBoxes().apply(converted_tkc)
     assert converted_tkc.n_gates_of_type(OpType.CX) == 4
     assert converted_tkc.n_gates_of_type(OpType.Ry) == 9
+    unitary1 = converted_tkc.get_unitary()
+    qc2 = tk_to_qiskit(converted_tkc)
+    tkc2 = qiskit_to_tk(qc2)
+    unitary2 = tkc2.get_unitary()
+    assert compare_unitaries(unitary1, unitary2)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -16,7 +16,7 @@ from collections import Counter
 from typing import List, Set, Union
 from math import pi
 import pytest
-from sympy import Symbol, symbols
+from sympy import Symbol
 import numpy as np
 from qiskit import (  # type: ignore
     QuantumCircuit,
@@ -24,7 +24,7 @@ from qiskit import (  # type: ignore
     ClassicalRegister,
     execute,
 )
-from qiskit.quantum_info import Pauli, SparsePauliOp  # type: ignore
+from qiskit.quantum_info import SparsePauliOp  # type: ignore
 from qiskit.transpiler import PassManager  # type: ignore
 from qiskit.circuit.library import RYGate, MCMT, XXPlusYYGate, PauliEvolutionGate, UnitaryGate, RealAmplitudes  # type: ignore
 import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -31,7 +31,7 @@ import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore
 from qiskit.circuit import Parameter
 from qiskit.synthesis import SuzukiTrotter  # type: ignore
 from qiskit_aer import Aer  # type: ignore
-from qiskit.quantum_info import Statevector
+from qiskit.quantum_info import Statevector, Operator
 
 from pytket.circuit import (
     Circuit,
@@ -1023,7 +1023,9 @@ def test_RealAmplitudes_numeric_params() -> None:
 
     real_amps2 = real_amps1.assign_parameters(params)
     qc.compose(real_amps2, qubits=[0, 1, 2], inplace=True)
-
+    # Unitary operator of the qiskit circuit. Order reversed from little -> big endian.
+    # The reversal means we can check it for equivalence with a tket unitary
+    qiskit_unitary = Operator(qc.reverse_bits()).data
     converted_tkc = qiskit_to_tk(qc)
     assert converted_tkc.n_gates == 1
     assert converted_tkc.n_gates_of_type(OpType.CircBox) == 1
@@ -1037,4 +1039,5 @@ def test_RealAmplitudes_numeric_params() -> None:
     qc2 = tk_to_qiskit(converted_tkc)
     tkc2 = qiskit_to_tk(qc2)
     unitary2 = tkc2.get_unitary()
+    assert compare_unitaries(qiskit_unitary, unitary1)
     assert compare_unitaries(unitary1, unitary2)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1014,7 +1014,6 @@ def test_failed_conversion_error() -> None:
     ):
         qiskit_to_tk(qc)
 
-from pytket.circuit.display import view_browser
 
 def test_RealAmplitudes_conversion() -> None:
     qc = QuantumCircuit(3)
@@ -1026,12 +1025,9 @@ def test_RealAmplitudes_conversion() -> None:
     qc.compose(real_amps2, qubits=[0, 1, 2], inplace=True)
 
     converted_tkc = qiskit_to_tk(qc)
-    view_browser(converted_tkc)
     assert converted_tkc.n_gates == 1
     assert converted_tkc.n_gates_of_type(OpType.CircBox) == 1
     DecomposeBoxes().apply(converted_tkc)
-    view_browser(converted_tkc)
-    print(converted_tkc.name)
     assert converted_tkc.name == "RealAmplitudes"
     assert converted_tkc.n_gates_of_type(OpType.CX) == 4
     assert converted_tkc.n_gates_of_type(OpType.Ry) == 9

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1018,10 +1018,8 @@ def test_failed_conversion_error() -> None:
 # https://github.com/CQCL/pytket-qiskit/issues/200
 def test_RealAmplitudes_numeric_params() -> None:
     qc = QuantumCircuit(3)
-
     params = [np.pi / 2] * 9
     real_amps1 = RealAmplitudes(3, reps=2)
-
     real_amps2 = real_amps1.assign_parameters(params)
     qc.compose(real_amps2, qubits=[0, 1, 2], inplace=True)
     # Unitary operator of the qiskit circuit. Order reversed from little -> big endian.

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -16,7 +16,7 @@ from collections import Counter
 from typing import List, Set, Union
 from math import pi
 import pytest
-from sympy import Symbol
+from sympy import Symbol, symbols
 import numpy as np
 from qiskit import (  # type: ignore
     QuantumCircuit,
@@ -1015,7 +1015,7 @@ def test_failed_conversion_error() -> None:
         qiskit_to_tk(qc)
 
 
-def test_RealAmplitudes_conversion() -> None:
+def test_RealAmplitudes_numeric_params() -> None:
     qc = QuantumCircuit(3)
 
     params = [np.pi / 2] * 9
@@ -1027,7 +1027,8 @@ def test_RealAmplitudes_conversion() -> None:
     converted_tkc = qiskit_to_tk(qc)
     assert converted_tkc.n_gates == 1
     assert converted_tkc.n_gates_of_type(OpType.CircBox) == 1
+    circbox_op = converted_tkc.get_commands()[0].op
+    assert circbox_op.get_circuit().name == "RealAmplitudes"
     DecomposeBoxes().apply(converted_tkc)
-    assert converted_tkc.name == "RealAmplitudes"
     assert converted_tkc.n_gates_of_type(OpType.CX) == 4
     assert converted_tkc.n_gates_of_type(OpType.Ry) == 9

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1028,6 +1028,7 @@ def test_RealAmplitudes_numeric_params() -> None:
     assert converted_tkc.n_gates == 1
     assert converted_tkc.n_gates_of_type(OpType.CircBox) == 1
     circbox_op = converted_tkc.get_commands()[0].op
+    assert isinstance(circbox_op, CircBox)
     assert circbox_op.get_circuit().name == "RealAmplitudes"
     DecomposeBoxes().apply(converted_tkc)
     assert converted_tkc.n_gates_of_type(OpType.CX) == 4

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1015,6 +1015,7 @@ def test_failed_conversion_error() -> None:
         qiskit_to_tk(qc)
 
 
+# https://github.com/CQCL/pytket-qiskit/issues/200
 def test_RealAmplitudes_numeric_params() -> None:
     qc = QuantumCircuit(3)
 


### PR DESCRIPTION
Addresses #200 

Consider the following example

```python
import numpy as np
from qiskit import QuantumCircuit
from qiskit.circuit.library import RealAmplitudes
from pytket.extensions.qiskit import qiskit_to_tk

qc = QuantumCircuit(3)

params = [np.pi/2]*9
supply1 = RealAmplitudes(3, reps=2)
   
supply1 = supply1.assign_parameters(params)
qc.compose(supply1, qubits = [0, 1, 2], inplace=True)
```

If we try to convert `qc` to a pytket `Circuit` with `qiskit_to_tk` then we get 

```
RuntimeError: Gate has an invalid number of parameters
```


Now pytket-qiskit converts the instruction to a `CustomGate`. The actual gate definition works fine but the `Circuit.add_custom_gate()` method is failing because there are no free symbols in the circuit.

I've decided to just handle this case with `CircBox` as I think its simpler.

There is still one assert failure in test which I'm puzzled by. This is the one that checks the name of the circuit.
**EDIT: Resolved**