### PR TITLE
Update credentials saving documentation

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -65,8 +65,6 @@ In this section we are assuming that you have set the following variables with t
     group = '<your_group_here>'
     project = '<your_project_here>'
 
-.. note:: The documentation below is correct as of pytket-qiskit version 0.40.0 and newer. In the 0.40.0 release pytket-qiskit moved to using the `qiskit-ibm-provider <https://qiskit.org/ecosystem/ibm-provider/tutorials/Migration_Guide_from_qiskit-ibmq-provider.html>`_. In pytket-qiskit versions 0.39.0 and older the parameters ``hub``, ``group`` and ``project`` were handled separately instead of a single ``instance`` string as in 0.40.0 and newer.
-
 ::
 
     from pytket.extensions.qiskit import set_ibmq_config
@@ -108,6 +106,8 @@ To see which devices you can access you can use the ``available_devices`` method
     backend = IBMQBackend("ibmq_nairobi") # Initialise backend for an IBM device
     backendinfo_list = backend.available_devices(instance=my_instance, provider=ibm_provider) 
     print([backend.device_name for backend in backendinfo_list])
+
+.. note:: The credentials documentation above is correct as of pytket-qiskit version 0.40.0 and newer. In pytket-qiskit versions 0.39.0 and older the parameters ``hub``, ``group`` and ``project`` were handled as separate kwargs instead of a single ``instance`` string as in 0.40.0 and newer. If you are using pytket-qiskit version 0.39 or older it is recommended to upgrade. See the IBM provider `migration guide <https://qiskit.org/ecosystem/ibm-provider/tutorials/Migration_Guide_from_qiskit-ibmq-provider.html>`_ for more information.
 
 
 Backends Available Through pytket-qiskit

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -191,7 +191,7 @@ Circuits must satisfy certain conditions before they can be processed on a devic
 
 All ``pytket-qiskit`` backends have the following two predicates.
 
-* `GateSetPredicate <https://tket.quantinuum.com/api-docs/predicates.html#pytket.predicates.GateSetPredicate>`_ - The circuit must contain only operations supported by the :py:class`Backend`. To view supported Ops run ``BACKENDNAME.backend_info.gate_set``.
+* `GateSetPredicate <https://tket.quantinuum.com/api-docs/predicates.html#pytket.predicates.GateSetPredicate>`_ - The circuit must contain only operations supported by the :py:class:`Backend`. To view supported Ops run ``Backend.backend_info.gate_set``.
 * `NoSymbolsPredicate <https://tket.quantinuum.com/api-docs/predicates.html#pytket.predicates.NoSymbolsPredicate>`_ - Parameterised gates must have numerical values when the circuit is executed.
 
 The :py:class:`IBMQBackend` and :py:class:`IBMQEmulatorBackend` may also have the following predicates depending on the capabilities of the specified device.


### PR DESCRIPTION
It was pointed out that the credentials saving docs are potentially misleading. I've moved the note about the use of pytket-qiskit v0.39 and older further down.