### PR TITLE
remove unsupported dynamic parameter

### DIFF
--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -510,7 +510,6 @@ class IBMQBackend(Backend):
                     sampler = Sampler(session=self._session, options=options)
                     job = sampler.run(
                         circuits=qcs,
-                        dynamic=self.backend_info.supports_fast_feedforward,
                     )
                     job_id = job.job_id()
                     for i, ind in enumerate(indices_chunk):


### PR DESCRIPTION
Summary: ci check on develop are not working, see for example https://github.com/CQCL/pytket-qiskit/actions/runs/6967703011/job/18968998699

I was not able to find the dynamic parameter in the qiskit documentation or changelog. It is unclear to my why this is not working.

I would assume that this parameter is not supported any more, but that is just guessing.

It is unclear to my, why this parameter was submitted to the backend again in the past, any helpful comments / opinions on this?

(We should also update https://cqcl.github.io/tket/pytket/api/predicates.html#pytket.predicates.NoFastFeedforwardPredicate it does not explain what this is used for)