### PR TITLE
Update python support to 3.10, 3.11 and 3.12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,37 +34,37 @@ jobs:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: Build and test including remote checks (3.10) mypy
+    - name: Build and test (3.10)
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+      shell: bash
+      run: |
+        ./.github/workflows/build-test nomypy
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Build and test including remote checks (3.11) mypy
       if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
       shell: bash
       run: |
         ./.github/workflows/build-test mypy
       env:
         PYTKET_RUN_REMOTE_TESTS: 1
-    - name: Build and test (3.10) nomypy
+    - name: Build and test (3.11) nomypy
       if:  (matrix.os != 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
     - name: Set up Python 3.12
-      if: github.event_name == 'push' || github.event_name == 'schedule'
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
     - name: Build and test (3.12)
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy
-    - name: Set up Python 3.11
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Build and test (3.11)
       if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       shell: bash
       run: |
@@ -119,10 +119,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Download all wheels
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,16 +33,6 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
-    - name: Set up Python 3.9
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.9'
-    - name: Build and test (3.9)
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
@@ -56,6 +46,16 @@ jobs:
         PYTKET_RUN_REMOTE_TESTS: 1
     - name: Build and test (3.10) nomypy
       if:  (matrix.os != 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
+      shell: bash
+      run: |
+        ./.github/workflows/build-test nomypy
+    - name: Set up Python 3.12
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Build and test (3.12)
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.11'
     - name: Upgrade pip and install wheel
       run: pip install --upgrade pip wheel
     - name: Install pytket qiskit

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ representations.
 
 ## Getting started
 
-`pytket-qiskit` is available for Python 3.10, 3.10 and 3.12, on Linux, MacOS
+`pytket-qiskit` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS
 and Windows. To install, run:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ representations.
 
 ## Getting started
 
-`pytket-qiskit` is available for Python 3.9, 3.10 and 3.11, on Linux, MacOS
+`pytket-qiskit` is available for Python 3.10, 3.10 and 3.12, on Linux, MacOS
 and Windows. To install, run:
 
 ```shell

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+General:
+
+* Python 3.12 support added; 3.9 dropped.
+
+
 0.47.0 (January 2024)
 ---------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,8 @@ Unreleased
 
 General:
 
-* Python 3.12 support added; 3.9 dropped.
+* Python 3.12 support added, 3.9 dropped.
+* pytket dependency updated to 1.24.
 
 
 0.47.0 (January 2024)

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -9,7 +9,7 @@ representations, simulation and access to the `IBMQ <https://www.research.ibm.co
 run on IBM backends and simulators, as well as conversion to and from Qiskit
 representations.
 
-``pytket-qiskit`` is available for Python 3.9, 3.10 and 3.11, on Linux, MacOS and
+``pytket-qiskit`` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS and
 Windows. To install, run:
 
 ::

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -4,7 +4,7 @@
     ],
     "language": {
         "name": "python",
-        "versions": ["3.9"]
+        "versions": ["3.10"]
     },
     "tests_command": [
         "/bin/bash -ec 'cd tests && pytest'"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 warn_unused_configs = True
 
 disallow_untyped_decorators = False

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version=metadata["__extension_version__"],
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     project_urls={
         "Documentation": "https://tket.quantinuum.com/extensions/pytket-qiskit/index.html",
         "Source": "https://github.com/CQCL/pytket-qiskit",
@@ -44,7 +44,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.23",
+        "pytket == 1.24.0rc0",
         "qiskit ~= 0.45.0",
         "qiskit-algorithms ~= 0.2.1",
         "qiskit-ibm-runtime ~= 0.17.0",
@@ -54,9 +54,9 @@ setup(
     ],
     classifiers=[
         "Environment :: Console",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.24.0rc0",
+        "pytket == 1.24",
         "qiskit ~= 0.45.0",
         "qiskit-algorithms ~= 0.2.1",
         "qiskit-ibm-runtime ~= 0.17.0",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket == 1.24",
+        "pytket ~= 1.24",
         "qiskit ~= 0.45.0",
         "qiskit-algorithms ~= 0.2.1",
         "qiskit-ibm-runtime ~= 0.17.0",


### PR DESCRIPTION
This PR drops python 3.9 support and adds python 3.12.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
