### PR TITLE
Pass `instance` to `QiskitRuntimeService`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Fix: use correct ``instance`` with ``IBMQEmulatorBackend``.
+
 0.48.0 (January 2024)
 ---------------------
 

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -85,7 +85,9 @@ class IBMQEmulatorBackend(Backend):
             token=token,
         )
 
-        self._service = QiskitRuntimeService(channel="ibm_quantum", token=token)
+        self._service = QiskitRuntimeService(
+            channel="ibm_quantum", instance=instance, token=token
+        )
         self._session = Session(service=self._service, backend="ibmq_qasm_simulator")
 
         # Get noise model:


### PR DESCRIPTION
# Description

Without this the default `ibm-q/open/main` instance is used for the `ibmq_qasm_simulator` backend.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
