### PR TITLE
Fix `Backend` links in API docs

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -122,15 +122,15 @@ and several types of simulator.
 
    * - Backend
      - Type
-   * - `IBMQBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.IBMQBackend>`_
+   * - `IBMQBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.IBMQBackend>`_
      - Interface to an IBM quantum computer.
-   * - `IBMQEmulatorBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.IBMQEmulatorBackend>`_
+   * - `IBMQEmulatorBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.IBMQEmulatorBackend>`_
      - Emulator for a chosen ``IBMBackend`` (Device specific).
-   * - `AerBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.AerBackend>`_
+   * - `AerBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.AerBackend>`_
      - A noiseless, shots-based simulator for quantum circuits [1]
-   * - `AerStateBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.AerStateBackend>`_
+   * - `AerStateBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.AerStateBackend>`_
      - Statevector simulator.
-   * - `AerUnitaryBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api/api.html#pytket.extensions.qiskit.AerUnitaryBackend>`_ 
+   * - `AerUnitaryBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.AerUnitaryBackend>`_ 
      - Unitary simulator
 
 * [1] :py:class:`AerBackend` is noiseless by default and has no architecture. However it can accept a user defined :py:class:`NoiseModel` and :py:class:`Architecture`.


### PR DESCRIPTION
# Description

Closes #261 

Fixes the links in the "Backends available through pytket-qiskit" section of the docs. Probably a copy/paste error.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
