### PR TITLE
Add local emulator backend

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,6 +11,11 @@ API documentation
     :show-inheritance:
     :members:
 
+.. autoclass:: pytket.extensions.qiskit.IBMQLocalEmulatorBackend
+    :special-members: __init__
+    :show-inheritance:
+    :members:
+
 .. autoclass:: pytket.extensions.qiskit.AerBackend
     :special-members: __init__
     :show-inheritance:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Add ``IBMQLocalEmulatorBackend`` for running local emulation of
+  ``IBMQBackend`` using ``AerBackend`` with a noise model.
+
 0.48.1rc1
 ---------
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -126,6 +126,8 @@ and several types of simulator.
      - Interface to an IBM quantum computer.
    * - `IBMQEmulatorBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.IBMQEmulatorBackend>`_
      - Emulator for a chosen ``IBMBackend`` (Device specific).
+   * - `IBMQLocalEmulatorBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.IBMQLocalEmulatorBackend>`_
+     - Emulator for a chosen ``IBMBackend`` that runs locally.
    * - `AerBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.AerBackend>`_
      - A noiseless, shots-based simulator for quantum circuits [1]
    * - `AerStateBackend <https://tket.quantinuum.com/extensions/pytket-qiskit/api.html#pytket.extensions.qiskit.AerStateBackend>`_
@@ -141,7 +143,7 @@ Default Compilation
 
 Every :py:class:`Backend` in pytket has its own ``default_compilation_pass`` method. This method applies a sequence of optimisations to a circuit depending on the value of an ``optimisation_level`` parameter. This default compilation will ensure that the circuit meets all the constraints required to run on the :py:class:`Backend`. The passes applied by different levels of optimisation are specified in the table below.
 
-.. list-table:: **Default compilation pass for the IBMQBackend and IBMQEmulatorBackend**
+.. list-table:: **Default compilation pass for the IBMQBackend, IBMQEmulatorBackend and IBMQLocalEmulatorBackend**
    :widths: 25 25 25
    :header-rows: 1
 

--- a/pytket/extensions/qiskit/__init__.py
+++ b/pytket/extensions/qiskit/__init__.py
@@ -22,6 +22,7 @@ from .backends import (
     AerStateBackend,
     AerUnitaryBackend,
     IBMQEmulatorBackend,
+    IBMQLocalEmulatorBackend,
 )
 from .backends.config import set_ibmq_config
 from .qiskit_convert import qiskit_to_tk, tk_to_qiskit, process_characterisation

--- a/pytket/extensions/qiskit/backends/__init__.py
+++ b/pytket/extensions/qiskit/backends/__init__.py
@@ -16,3 +16,4 @@
 from .ibm import IBMQBackend, NoIBMQCredentialsError
 from .aer import AerBackend, AerStateBackend, AerUnitaryBackend
 from .ibmq_emulator import IBMQEmulatorBackend
+from .ibmq_local_emulator import IBMQLocalEmulatorBackend

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -57,7 +57,7 @@ class IBMQEmulatorBackend(Backend):
     """A Backend which uses the ibmq_qasm_simulator to emulate the behaviour of
     IBMQBackend. Identical to :py:class:`IBMQBackend` except there is no `monitor`
     parameter. Performs the same compilation and predicate checks as IBMQBackend.
-    Requires a valid IBM account.
+    Requires a valid IBMQ account.
     """
 
     _supports_shots = False

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -54,7 +54,7 @@ from .ibm_utils import _STATUS_MAP, _batch_circuits
 
 
 class IBMQEmulatorBackend(Backend):
-    """A backend which uses the AerBackend simulator to emulate the behaviour of
+    """A backend which uses the ibmq_qasm_simulator to emulate the behaviour of
     IBMQBackend. Performs the same compilation and predicate checks as IBMQBackend.
     Requires a valid IBMQ account.
 

--- a/pytket/extensions/qiskit/backends/ibmq_local_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_local_emulator.py
@@ -1,0 +1,140 @@
+# Copyright 2019-2024 Cambridge Quantum Computing
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import Counter
+from typing import (
+    Dict,
+    Optional,
+    List,
+    Sequence,
+    Tuple,
+    Union,
+)
+
+from qiskit.providers.aer.noise.noise_model import NoiseModel  # type: ignore
+
+from qiskit_ibm_provider import IBMProvider  # type: ignore
+
+from pytket.backends import (
+    Backend,
+    ResultHandle,
+    CircuitStatus,
+)
+from pytket.backends.backendinfo import BackendInfo
+from pytket.backends.backendresult import BackendResult
+from pytket.backends.resulthandle import _ResultIdTuple
+from pytket.circuit import Circuit
+from pytket.passes import BasePass
+from pytket.predicates import Predicate
+from pytket.utils.results import KwargTypes
+
+from .aer import AerBackend
+from .ibm import IBMQBackend
+
+
+class IBMQLocalEmulatorBackend(Backend):
+    """A backend which uses the AerBackend to locally emulate the behaviour of
+    IBMQBackend. Performs the same compilation and predicate checks as IBMQBackend.
+    Requires a valid IBMQ account.
+
+    """
+
+    _supports_shots = False
+    _supports_counts = True
+    _supports_contextual_optimisation = False
+    _persistent_handles = False
+    _supports_expectation = False
+
+    def __init__(
+        self,
+        backend_name: str,
+        instance: Optional[str] = None,
+        provider: Optional["IBMProvider"] = None,
+        token: Optional[str] = None,
+    ):
+        """Construct an IBMQLocalEmulatorBackend. Identical to :py:class:`IBMQBackend`
+        constructor, except there is no `monitor` parameter. See :py:class:`IBMQBackend`
+        docs for more details.
+        """
+        super().__init__()
+        self._ibmq = IBMQBackend(
+            backend_name=backend_name,
+            instance=instance,
+            provider=provider,
+            token=token,
+        )
+
+        # Get noise model:
+        self._noise_model = NoiseModel.from_backend(self._ibmq._backend)
+
+        # Construct AerBackend based on noise model:
+        self._aer = AerBackend(noise_model=self._noise_model)
+
+        # cache of results keyed by job id and circuit index
+        self._ibm_res_cache: Dict[Tuple[str, int], Counter] = dict()
+
+    @property
+    def backend_info(self) -> BackendInfo:
+        return self._ibmq._backend_info
+
+    @property
+    def required_predicates(self) -> List[Predicate]:
+        return self._ibmq.required_predicates
+
+    def default_compilation_pass(
+        self, optimisation_level: int = 2, placement_options: Optional[Dict] = None
+    ) -> BasePass:
+        """
+        See documentation for :py:meth:`IBMQBackend.default_compilation_pass`.
+        """
+        return self._ibmq.default_compilation_pass(
+            optimisation_level=optimisation_level, placement_options=placement_options
+        )
+
+    @property
+    def _result_id_type(self) -> _ResultIdTuple:
+        return self._aer._result_id_type
+
+    def rebase_pass(self) -> BasePass:
+        return self._ibmq.rebase_pass()
+
+    def process_circuits(
+        self,
+        circuits: Sequence[Circuit],
+        n_shots: Union[None, int, Sequence[Optional[int]]] = None,
+        valid_check: bool = True,
+        **kwargs: KwargTypes,
+    ) -> List[ResultHandle]:
+        """
+        See :py:meth:`pytket.backends.Backend.process_circuits`.
+        Supported kwargs: `seed`, `postprocess`.
+        """
+        if valid_check:
+            self._ibmq._check_all_circuits(circuits)
+        return self._aer.process_circuits(
+            circuits, n_shots=n_shots, valid_check=False, **kwargs
+        )
+
+    def cancel(self, handle: ResultHandle) -> None:
+        self._aer.cancel(handle)
+
+    def circuit_status(self, handle: ResultHandle) -> CircuitStatus:
+        return self._aer.circuit_status(handle)
+
+    def get_result(self, handle: ResultHandle, **kwargs: KwargTypes) -> BackendResult:
+        """
+        See :py:meth:`pytket.backends.Backend.get_result`.
+        Supported kwargs: none.
+        """
+        return self._aer.get_result(handle)

--- a/pytket/extensions/qiskit/backends/ibmq_local_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_local_emulator.py
@@ -44,10 +44,10 @@ from .ibm import IBMQBackend
 
 
 class IBMQLocalEmulatorBackend(Backend):
-    """A backend which uses the AerBackend to locally emulate the behaviour of
-    IBMQBackend. Performs the same compilation and predicate checks as IBMQBackend.
-    Requires a valid IBMQ account.
-
+    """A backend which uses the AerBackend to loaclly emulate the behaviour of
+    IBMQBackend. Identical to :py:class:`IBMQBackend` except there is no `monitor`
+    parameter. Performs the same compilation and predicate checks as IBMQBackend.
+    Requires a valid IBM account.
     """
 
     _supports_shots = False
@@ -63,10 +63,6 @@ class IBMQLocalEmulatorBackend(Backend):
         provider: Optional["IBMProvider"] = None,
         token: Optional[str] = None,
     ):
-        """Construct an IBMQLocalEmulatorBackend. Identical to :py:class:`IBMQBackend`
-        constructor, except there is no `monitor` parameter. See :py:class:`IBMQBackend`
-        docs for more details.
-        """
         super().__init__()
         self._ibmq = IBMQBackend(
             backend_name=backend_name,

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -469,8 +469,11 @@ def test_nshots_batching(brisbane_backend: IBMQBackend) -> None:
 
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
-def test_nshots(brisbane_emulator_backend: IBMQEmulatorBackend) -> None:
-    for b in [AerBackend(), brisbane_emulator_backend]:
+def test_nshots(
+    brisbane_emulator_backend: IBMQEmulatorBackend,
+    brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
+) -> None:
+    for b in [AerBackend(), brisbane_emulator_backend, brisbane_local_emulator_backend]:
         circuit = Circuit(1).X(0)
         circuit.measure_all()
         n_shots = [1, 2, 3]
@@ -831,43 +834,42 @@ def test_operator_expectation_value() -> None:
 
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
-def test_ibmq_emulator(brisbane_emulator_backend: IBMQEmulatorBackend) -> None:
-    assert brisbane_emulator_backend._noise_model is not None
-    b_ibm = brisbane_emulator_backend._ibmq
-    b_aer = AerBackend()
-    for ol in range(3):
-        comp_pass = brisbane_emulator_backend.default_compilation_pass(ol)
-        c = Circuit(3, 3)
-        c.H(0)
-        c.CX(0, 1)
-        c.CSWAP(1, 0, 2)
-        c.ZZPhase(0.84, 2, 0)
-        c_cop = c.copy()
-        comp_pass.apply(c_cop)
-        c.measure_all()
-        for bac in (brisbane_emulator_backend, b_ibm):
-            assert all(pred.verify(c_cop) for pred in bac.required_predicates)
+def test_ibmq_emulator(
+    brisbane_emulator_backend: IBMQEmulatorBackend,
+    brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
+) -> None:
+    for b in [brisbane_emulator_backend, brisbane_local_emulator_backend]:
+        assert b._noise_model is not None  # type: ignore
+        b_ibm = b._ibmq  # type: ignore
+        b_aer = AerBackend()
+        for ol in range(3):
+            comp_pass = b.default_compilation_pass(ol)
+            c = Circuit(3, 3)
+            c.H(0)
+            c.CX(0, 1)
+            c.CSWAP(1, 0, 2)
+            c.ZZPhase(0.84, 2, 0)
+            c_cop = c.copy()
+            comp_pass.apply(c_cop)
+            c.measure_all()
+            for bac in (b, b_ibm):
+                assert all(pred.verify(c_cop) for pred in bac.required_predicates)
 
-        c_cop_2 = c.copy()
-        c_cop_2 = b_aer.get_compiled_circuit(c_cop_2, ol)
-        if ol == 0:
-            assert not all(
-                pred.verify(c_cop_2)
-                for pred in brisbane_emulator_backend.required_predicates
-            )
+            c_cop_2 = c.copy()
+            c_cop_2 = b_aer.get_compiled_circuit(c_cop_2, ol)
+            if ol == 0:
+                assert not all(pred.verify(c_cop_2) for pred in b.required_predicates)
 
-    circ = Circuit(2, 2).H(0).CX(0, 1).measure_all()
-    copy_circ = circ.copy()
-    brisbane_emulator_backend.rebase_pass().apply(copy_circ)
-    assert brisbane_emulator_backend.required_predicates[1].verify(copy_circ)
-    circ = brisbane_emulator_backend.get_compiled_circuit(circ)
-    b_noi = AerBackend(noise_model=brisbane_emulator_backend._noise_model)
-    emu_counts = brisbane_emulator_backend.run_circuit(
-        circ, n_shots=10, seed=10
-    ).get_counts()
-    aer_counts = b_noi.run_circuit(circ, n_shots=10, seed=10).get_counts()
-    # Even with the same seed, the results may differ.
-    assert sum(emu_counts.values()) == sum(aer_counts.values())
+        circ = Circuit(2, 2).H(0).CX(0, 1).measure_all()
+        copy_circ = circ.copy()
+        b.rebase_pass().apply(copy_circ)
+        assert b.required_predicates[1].verify(copy_circ)
+        circ = b.get_compiled_circuit(circ)
+        b_noi = AerBackend(noise_model=b._noise_model)  # type: ignore
+        emu_counts = b.run_circuit(circ, n_shots=10, seed=10).get_counts()
+        aer_counts = b_noi.run_circuit(circ, n_shots=10, seed=10).get_counts()
+        # Even with the same seed, the results may differ.
+        assert sum(emu_counts.values()) == sum(aer_counts.values())
 
 
 @given(
@@ -1166,12 +1168,14 @@ def test_available_devices(ibm_provider: IBMProvider) -> None:
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_backendinfo_serialization1(
     brisbane_emulator_backend: IBMQEmulatorBackend,
+    brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
 ) -> None:
     # https://github.com/CQCL/tket/issues/192
-    backend_info_json = brisbane_emulator_backend.backend_info.to_dict()
-    s = json.dumps(backend_info_json)
-    backend_info_json1 = json.loads(s)
-    assert backend_info_json == backend_info_json1
+    for b in [brisbane_emulator_backend, brisbane_local_emulator_backend]:
+        backend_info_json = b.backend_info.to_dict()  # type: ignore
+        s = json.dumps(backend_info_json)
+        backend_info_json1 = json.loads(s)
+        assert backend_info_json == backend_info_json1
 
 
 def test_backendinfo_serialization2() -> None:
@@ -1219,20 +1223,24 @@ def test_sim_qubit_order() -> None:
 
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
-def test_requrired_predicates(brisbane_emulator_backend: IBMQEmulatorBackend) -> None:
+def test_required_predicates(
+    brisbane_emulator_backend: IBMQEmulatorBackend,
+    brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
+) -> None:
     # https://github.com/CQCL/pytket-qiskit/issues/93
-    circ = Circuit(8)  # 8 qubit circuit in IBMQ gateset
-    circ.X(0).CX(0, 1).CX(0, 2).CX(0, 3).CX(0, 4).CX(0, 5).CX(0, 6).CX(
-        0, 7
-    ).measure_all()
-    with pytest.raises(CircuitNotValidError) as errorinfo:
-        brisbane_emulator_backend.run_circuit(circ, n_shots=100)
-        assert (
-            "pytket.backends.backend_exceptions.CircuitNotValidError:"
-            + "Circuit with index 0 in submitted does"
-            + "not satisfy MaxNQubitsPredicate(5)"
-            in str(errorinfo)
-        )
+    for b in [brisbane_emulator_backend, brisbane_local_emulator_backend]:
+        circ = Circuit(8)  # 8 qubit circuit in IBMQ gateset
+        circ.X(0).CX(0, 1).CX(0, 2).CX(0, 3).CX(0, 4).CX(0, 5).CX(0, 6).CX(
+            0, 7
+        ).measure_all()
+        with pytest.raises(CircuitNotValidError) as errorinfo:
+            b.run_circuit(circ, n_shots=100)
+            assert (
+                "pytket.backends.backend_exceptions.CircuitNotValidError:"
+                + "Circuit with index 0 in submitted does"
+                + "not satisfy MaxNQubitsPredicate(5)"
+                in str(errorinfo)
+            )
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=10)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,11 @@ import os
 import pytest
 
 from qiskit_ibm_provider import IBMProvider  # type: ignore
-from pytket.extensions.qiskit import IBMQBackend, IBMQEmulatorBackend
+from pytket.extensions.qiskit import (
+    IBMQBackend,
+    IBMQEmulatorBackend,
+    IBMQLocalEmulatorBackend,
+)
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -76,6 +80,15 @@ def brisbane_emulator_backend() -> IBMQEmulatorBackend:
 @pytest.fixture(scope="module")
 def nairobi_emulator_backend() -> IBMQEmulatorBackend:
     return IBMQEmulatorBackend(
+        "ibm_brisbane",
+        instance="ibm-q/open/main",
+        token=os.getenv("PYTKET_REMOTE_QISKIT_TOKEN"),
+    )
+
+
+@pytest.fixture(scope="module")
+def brisbane_local_emulator_backend() -> IBMQLocalEmulatorBackend:
+    return IBMQLocalEmulatorBackend(
         "ibm_brisbane",
         instance="ibm-q/open/main",
         token=os.getenv("PYTKET_REMOTE_QISKIT_TOKEN"),


### PR DESCRIPTION
# Description

Add a new backend `IBMQLocalEmulatorBackend` which uses `AerBackend` with the noise model and characteristics of the real device. This is similar to `IBMQEmulatorBackend` except that it does all emulation locally. The only outward difference is that it does not support contextual optimization (because `AerBackend` doesn't).

# Related issues

Closes #65 .

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
