### PR TITLE
Improve docs on saving IBM credentials

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -118,6 +118,7 @@ To see which devices you can access you can use the ``available_devices`` method
     my_instance=f"{hub}/{group}/{project}"
     ibm_provider = IBMProvider(instance=my_instance)
     backend = IBMQBackend("ibmq_nairobi") # Initialise backend for an IBM device
+    
     backendinfo_list = backend.available_devices(instance=my_instance, provider=ibm_provider) 
     print([backend.device_name for backend in backendinfo_list])
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -81,10 +81,10 @@ In this section we are assuming that you have set the following variables with t
     group = '<your_group_here>'
     project = '<your_project_here>'
 
-Method 1: Using :py:meth:`IBMProvider.save_account`
----------------------------------------------------
+Method 1: Using :py:class:`IBMProvider`
+---------------------------------------
 
-You can use the following qiskit commands to save your credentials
+You can use the following qiskit commands to save your IBM credentials
 to disk:
 
 ::

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -100,8 +100,6 @@ If you are a member of an IBM hub then you can add this information to ``set_ibm
 Alternatively you can use the following qiskit commands to save your credentials
 locally without saving the token in pytket config:
 
-.. note:: If using pytket-qiskit 0.39.0 or older you will have to use the deprecated :py:meth:`IBMQ.save_account` instead of :py:meth:`IBMProvider.save_account` in the code below.
-
 ::
 
     from qiskit_ibm_provider import IBMProvider

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -81,6 +81,9 @@ In this section we are assuming that you have set the following variables with t
     group = '<your_group_here>'
     project = '<your_project_here>'
 
+Method 1:
+---------
+
 ::
 
     from pytket.extensions.qiskit import set_ibmq_config
@@ -104,6 +107,9 @@ If you are a member of an IBM hub then you can add this information to ``set_ibm
 
     QiskitConfig
     set_ibmq_config
+
+Method 2:
+---------
 
 Alternatively you can use the following qiskit commands to save your credentials
 locally without saving the token in pytket config:

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -196,7 +196,7 @@ Every :py:class:`Backend` in pytket has its own ``default_compilation_pass`` met
      - `RemoveRedundancies <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.RemoveRedundancies>`_ 
 
 * [1] If no value is specified then ``optimisation_level`` defaults to a value of 2.
-* [2] self.rebase_pass is a rebase to the gateset supported by the backend, For IBM quantum devices and emulators that is either {X, SX, Rz, CX} or {X, SX, Rz, ECR}. The more idealised Aer simulators have a much broader range of supported gates.
+* [2] self.rebase_pass is a rebase to the gateset supported by the backend. For IBM quantum devices and emulators that is either {X, SX, Rz, CX} or {X, SX, Rz, ECR}. The more idealised Aer simulators have a much broader range of supported gates.
 * [3] Here :py:class:`CXMappingPass` maps program qubits to the architecture using a `NoiseAwarePlacement <https://tket.quantinuum.com/api-docs/placement.html#pytket.placement.NoiseAwarePlacement>`_
 
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -81,8 +81,39 @@ In this section we are assuming that you have set the following variables with t
     group = '<your_group_here>'
     project = '<your_project_here>'
 
-Method 1:
----------
+Method 1: Using :py:meth:`IBMProvider.save_account`
+---------------------------------------------------
+
+You can use the following qiskit commands to save your credentials
+to disk:
+
+::
+
+    from qiskit_ibm_provider import IBMProvider
+    from qiskit_ibm_runtime import QiskitRuntimeService
+
+    IBMProvider.save_account(token=ibm_token)
+    QiskitRuntimeService.save_account(channel="ibm_quantum", token=ibm_token)
+
+To see which devices you can access you can use the ``available_devices`` method on the :py:class:`IBMQBackend` or :py:class:`IBMQEmulatorBackend`. Note that it is possible to pass optional ``instance`` and ``provider`` arguments to this method. This allows you to see which devices are accessible through your IBM hub.
+
+::
+
+    from pytket.extensions.qiskit import IBMQBackend
+    from qiskit_ibm_provider import IBMProvider
+
+    my_instance=f"{hub}/{group}/{project}"
+    ibm_provider = IBMProvider(instance=my_instance)
+    backend = IBMQBackend("ibmq_nairobi") # Initialise backend for an IBM device
+
+    backendinfo_list = backend.available_devices(instance=my_instance, provider=ibm_provider) 
+    print([backend.device_name for backend in backendinfo_list])
+
+
+
+Method 2: Saving Credentials in a local pytket config file
+----------------------------------------------------------
+Alternatively, you can store your credentials in local pytket config using the :py:meth:`set_ibmq_config` method.
 
 ::
 
@@ -107,35 +138,6 @@ If you are a member of an IBM hub then you can add this information to ``set_ibm
 
     QiskitConfig
     set_ibmq_config
-
-Method 2:
----------
-
-Alternatively you can use the following qiskit commands to save your credentials
-locally without saving the token in pytket config:
-
-::
-
-    from qiskit_ibm_provider import IBMProvider
-    from qiskit_ibm_runtime import QiskitRuntimeService
-
-    IBMProvider.save_account(token=ibm_token)
-    QiskitRuntimeService.save_account(channel="ibm_quantum", token=ibm_token)
-
-To see which devices you can access you can use the ``available_devices`` method on the :py:class:`IBMQBackend` or :py:class:`IBMQEmulatorBackend`. Note that it is possible to pass optional ``instance`` and ``provider`` arguments to this method. This allows you to see which devices are accessible through your IBM hub.
-
-::
-
-    from pytket.extensions.qiskit import IBMQBackend
-    from qiskit_ibm_provider import IBMProvider
-
-    my_instance=f"{hub}/{group}/{project}"
-    ibm_provider = IBMProvider(instance=my_instance)
-    backend = IBMQBackend("ibmq_nairobi") # Initialise backend for an IBM device
-
-    backendinfo_list = backend.available_devices(instance=my_instance, provider=ibm_provider) 
-    print([backend.device_name for backend in backendinfo_list])
-
 
 Converting circuits between pytket and qiskit
 =============================================

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -118,7 +118,7 @@ To see which devices you can access you can use the ``available_devices`` method
     my_instance=f"{hub}/{group}/{project}"
     ibm_provider = IBMProvider(instance=my_instance)
     backend = IBMQBackend("ibmq_nairobi") # Initialise backend for an IBM device
-    
+
     backendinfo_list = backend.available_devices(instance=my_instance, provider=ibm_provider) 
     print([backend.device_name for backend in backendinfo_list])
 
@@ -189,7 +189,7 @@ Every :py:class:`Backend` in pytket has its own ``default_compilation_pass`` met
      - `RemoveRedundancies <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.RemoveRedundancies>`_ 
 
 * [1] If no value is specified then ``optimisation_level`` defaults to a value of 2.
-* [2] self.rebase_pass is a rebase to the gateset supported by the backend, For IBM quantum devices that is {X, SX, Rz, CX}.
+* [2] self.rebase_pass is a rebase to the gateset supported by the backend, For IBM quantum devices and emulators that is either {X, SX, Rz, CX} or {X, SX, Rz, ECR}. The more idealised Aer simulators have a much broader range of supported gates.
 * [3] Here :py:class:`CXMappingPass` maps program qubits to the architecture using a `NoiseAwarePlacement <https://tket.quantinuum.com/api-docs/placement.html#pytket.placement.NoiseAwarePlacement>`_
 
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -111,7 +111,7 @@ To see which devices you can access you can use the ``available_devices`` method
 
 
 
-Method 2: Saving Credentials in a local pytket config file
+Method 2: Saving credentials in a local pytket config file
 ----------------------------------------------------------
 Alternatively, you can store your credentials in local pytket config using the :py:meth:`set_ibmq_config` method.
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -81,8 +81,6 @@ In this section we are assuming that you have set the following variables with t
     group = '<your_group_here>'
     project = '<your_project_here>'
 
-.. note:: The documentation below is correct as of pytket-qiskit version 0.40.0 and newer. In the 0.40.0 release pytket-qiskit moved to using the `qiskit-ibm-provider <https://github.com/Qiskit/qiskit-ibm-provider>`_. In pytket-qiskit versions 0.39.0 and older the parameters ``hub``, ``group`` and ``project`` were handled separately instead of a single ``instance`` string as in 0.40.0 and newer.
-
 ::
 
     from pytket.extensions.qiskit import set_ibmq_config

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -97,6 +97,14 @@ If you are a member of an IBM hub then you can add this information to ``set_ibm
 
     set_ibmq_config(ibmq_api_token=ibm_token, instance=f"{hub}/{group}/{project}")
 
+.. currentmodule:: pytket.extensions.qiskit.backends.config
+
+.. autosummary::
+    :nosignatures:
+
+    QiskitConfig
+    set_ibmq_config
+
 Alternatively you can use the following qiskit commands to save your credentials
 locally without saving the token in pytket config:
 
@@ -121,15 +129,6 @@ To see which devices you can access you can use the ``available_devices`` method
 
     backendinfo_list = backend.available_devices(instance=my_instance, provider=ibm_provider) 
     print([backend.device_name for backend in backendinfo_list])
-
-
-.. currentmodule:: pytket.extensions.qiskit.backends.config
-
-.. autosummary::
-    :nosignatures:
-
-    QiskitConfig
-    set_ibmq_config
 
 
 Converting circuits between pytket and qiskit


### PR DESCRIPTION
# Description

Updated the docs on saving IBM credentials. I think we can safely remove the notes about using pytket-qiskit v0.39 or older at this point.

I've also explicitly separted the two methods for saving credentials. Hopefully this avoids some confusion.

<img width="553" alt="Screenshot 2024-03-05 at 11 30 29" src="https://github.com/CQCL/pytket-qiskit/assets/93673602/72c08281-70f4-4502-8fd4-4eaaee9ff526">


# Related issues

Closes #275 

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
