### PR TITLE
fix brisbane not working with ibmq_qasm_simulator anymore

### DIFF
--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -89,11 +89,13 @@ class IBMQEmulatorBackend(Backend):
         # Get noise model:
         self._noise_model = NoiseModel.from_backend(self._ibmq._backend)
 
-        if self._ibmq._backend._backend_info.n_nodes > 32:
-            raise ValueError("ibmq_qasm_simulator only supports 32 qubits, \
-devices with more than 32 qubtis can't be simulated")
+        if self._ibmq._backend_info.n_nodes > 32:
+            raise ValueError(
+                "ibmq_qasm_simulator only supports 32 qubits, \
+devices with more than 32 qubtis can't be simulated"
+            )
 
-        if OpType.ECR in self._ibmq._backend._primitive_gates:
+        if OpType.ECR in self._ibmq._primitive_gates:
             raise ValueError("ibmq_qasm_simulator does not support ECR in gateset")
 
         # cache of results keyed by job id and circuit index

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -89,6 +89,13 @@ class IBMQEmulatorBackend(Backend):
         # Get noise model:
         self._noise_model = NoiseModel.from_backend(self._ibmq._backend)
 
+        if self._ibmq._backend._backend_info.n_nodes > 32:
+            raise ValueError("ibmq_qasm_simulator only supports 32 qubits, \
+devices with more than 32 qubtis can't be simulated")
+
+        if OpType.ECR in self._ibmq._backend._primitive_gates:
+            raise ValueError("ibmq_qasm_simulator does not support ECR in gateset")
+
         # cache of results keyed by job id and circuit index
         self._ibm_res_cache: Dict[Tuple[str, int], Counter] = dict()
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -856,6 +856,8 @@ def test_ibmq_emulator(
 
             c_cop_2 = c.copy()
             c_cop_2 = b_aer.get_compiled_circuit(c_cop_2, ol)
+            if ol == 0:
+                assert not all(pred.verify(c_cop_2) for pred in b.required_predicates)
 
         circ = Circuit(2, 2).H(0).CX(0, 1).measure_all()
         copy_circ = circ.copy()
@@ -1128,7 +1130,7 @@ def test_postprocess_emu(ibmq_qasm_emulator_backend: IBMQEmulatorBackend) -> Non
 
 # https://github.com/CQCL/pytket-qiskit/issues/278
 # @pytest.mark.flaky(reruns=3, reruns_delay=10)
-@pytest.mark.xfail(reason="Qiskit rejecting cx")
+# @pytest.mark.xfail(reason="Qiskit rejecting cx")
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
     c = Circuit(2, 2)
@@ -1143,7 +1145,7 @@ def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
 
 
 # https://github.com/CQCL/pytket-qiskit/issues/278
-@pytest.mark.xfail(reason="Qiskit rejecting cx")
+# @pytest.mark.xfail(reason="Qiskit rejecting cx")
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_cloud_stabiliser_0() -> None:
     num_qubits = 2
@@ -1189,11 +1191,10 @@ def test_available_devices(ibm_provider: IBMProvider) -> None:
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_backendinfo_serialization1(
-    brisbane_emulator_backend: IBMQEmulatorBackend,
     brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
 ) -> None:
     # https://github.com/CQCL/tket/issues/192
-    for b in [brisbane_emulator_backend, brisbane_local_emulator_backend]:
+    for b in [brisbane_local_emulator_backend]:
         backend_info_json = b.backend_info.to_dict()  # type: ignore
         s = json.dumps(backend_info_json)
         backend_info_json1 = json.loads(s)
@@ -1246,11 +1247,10 @@ def test_sim_qubit_order() -> None:
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_required_predicates(
-    brisbane_emulator_backend: IBMQEmulatorBackend,
     brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
 ) -> None:
     # https://github.com/CQCL/pytket-qiskit/issues/93
-    for b in [brisbane_emulator_backend, brisbane_local_emulator_backend]:
+    for b in [brisbane_local_emulator_backend]:
         circ = Circuit(8)  # 8 qubit circuit in IBMQ gateset
         circ.X(0).CX(0, 1).CX(0, 2).CX(0, 3).CX(0, 4).CX(0, 5).CX(0, 6).CX(
             0, 7

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -835,10 +835,10 @@ def test_operator_expectation_value() -> None:
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ibmq_emulator(
-    brisbane_emulator_backend: IBMQEmulatorBackend,
+    ibmq_qasm_emulator_backend: IBMQEmulatorBackend,
     brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
 ) -> None:
-    for b in [brisbane_emulator_backend, brisbane_local_emulator_backend]:
+    for b in [ibmq_qasm_emulator_backend, brisbane_local_emulator_backend]:
         assert b._noise_model is not None  # type: ignore
         b_ibm = b._ibmq  # type: ignore
         b_aer = AerBackend()
@@ -857,8 +857,8 @@ def test_ibmq_emulator(
 
             c_cop_2 = c.copy()
             c_cop_2 = b_aer.get_compiled_circuit(c_cop_2, ol)
-            if ol == 0:
-                assert not all(pred.verify(c_cop_2) for pred in b.required_predicates)
+            # if ol == 0:
+            #    assert not all(pred.verify(c_cop_2) for pred in b.required_predicates)
 
         circ = Circuit(2, 2).H(0).CX(0, 1).measure_all()
         copy_circ = circ.copy()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -470,10 +470,9 @@ def test_nshots_batching(brisbane_backend: IBMQBackend) -> None:
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_nshots(
-    brisbane_emulator_backend: IBMQEmulatorBackend,
     brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
 ) -> None:
-    for b in [AerBackend(), brisbane_emulator_backend, brisbane_local_emulator_backend]:
+    for b in [AerBackend(), brisbane_local_emulator_backend]:
         circuit = Circuit(1).X(0)
         circuit.measure_all()
         n_shots = [1, 2, 3]
@@ -835,10 +834,9 @@ def test_operator_expectation_value() -> None:
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ibmq_emulator(
-    ibmq_qasm_emulator_backend: IBMQEmulatorBackend,
     brisbane_local_emulator_backend: IBMQLocalEmulatorBackend,
 ) -> None:
-    for b in [ibmq_qasm_emulator_backend, brisbane_local_emulator_backend]:
+    for b in [brisbane_local_emulator_backend]:
         assert b._noise_model is not None  # type: ignore
         b_ibm = b._ibmq  # type: ignore
         b_aer = AerBackend()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -857,8 +857,6 @@ def test_ibmq_emulator(
 
             c_cop_2 = c.copy()
             c_cop_2 = b_aer.get_compiled_circuit(c_cop_2, ol)
-            # if ol == 0:
-            #    assert not all(pred.verify(c_cop_2) for pred in b.required_predicates)
 
         circ = Circuit(2, 2).H(0).CX(0, 1).measure_all()
         copy_circ = circ.copy()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1130,7 +1130,7 @@ def test_postprocess_emu(ibmq_qasm_emulator_backend: IBMQEmulatorBackend) -> Non
 
 # https://github.com/CQCL/pytket-qiskit/issues/278
 # @pytest.mark.flaky(reruns=3, reruns_delay=10)
-# @pytest.mark.xfail(reason="Qiskit rejecting cx")
+@pytest.mark.xfail(reason="Qiskit rejecting cx")
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
     c = Circuit(2, 2)
@@ -1145,7 +1145,8 @@ def test_cloud_stabiliser(simulator_stabilizer_backend: IBMQBackend) -> None:
 
 
 # https://github.com/CQCL/pytket-qiskit/issues/278
-# @pytest.mark.xfail(reason="Qiskit rejecting cx")
+# @pytest.mark.flaky(reruns=3, reruns_delay=10)
+@pytest.mark.xfail(reason="Qiskit rejecting cx")
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_cloud_stabiliser_0() -> None:
     num_qubits = 2


### PR DESCRIPTION
# Description

All devices available in the open plan have more then the 32 qubits that are supported by the ibmq_qasm_simulator. So we need to replace them. Not sure what the best strategy is... 


# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
