### PR TITLE
Bump qiskit-algorithms dep to 0.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     install_requires=[
         "pytket ~= 1.25",
         "qiskit ~= 1.0",
-        "qiskit-algorithms ~= 0.2.1",
+        "qiskit-algorithms ~= 0.3.0",
         "qiskit-ibm-runtime ~= 0.21.0",
         "qiskit-aer ~= 0.13.3",
         "qiskit-ibm-provider ~= 0.10.0",


### PR DESCRIPTION
# Description

Update the version of `qiskit-algorithms` to 0.3.0 as it's the first version that supports `qiskit` 1.0. https://qiskit-community.github.io/qiskit-algorithms/release_notes.html#release-notes-0-3-0

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
