### PR TITLE
Internal/narrow types required for compilation

### DIFF
--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -32,7 +32,7 @@ from typing import (
 )
 from warnings import warn
 
-from qiskit.providers.models import BackendProperties, QasmBackendConfiguration
+from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 from qiskit_ibm_provider import IBMProvider  # type: ignore
 from qiskit_ibm_provider.exceptions import IBMProviderError  # type: ignore
 from qiskit.primitives import SamplerResult  # type: ignore

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -32,7 +32,6 @@ from typing import (
 )
 from warnings import warn
 
-from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 from qiskit_ibm_provider import IBMProvider  # type: ignore
 from qiskit_ibm_provider.exceptions import IBMProviderError  # type: ignore
 from qiskit.primitives import SamplerResult  # type: ignore
@@ -57,16 +56,15 @@ from pytket.backends import (
     CircuitNotRunError,
     CircuitStatus,
     ResultHandle,
-    backend,
 )
 from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
 from pytket.backends.resulthandle import _ResultIdTuple
-from ..qiskit_convert import (
+from pytket.extensions.qiskit.qiskit_convert import (
     get_avg_characterisation,
     process_characterisation_from_config,
 )
-from .._metadata import __extension_version__
+from pytket.extensions.qiskit._metadata import __extension_version__
 from pytket.passes import (
     BasePass,
     auto_rebase_pass,
@@ -90,7 +88,7 @@ from pytket.predicates import (
     MaxNQubitsPredicate,
     Predicate,
 )
-from ..qiskit_convert import tk_to_qiskit, _tk_gate_set
+from pytket.extensions.qiskit.qiskit_convert import tk_to_qiskit, _tk_gate_set
 from pytket.architecture import FullyConnected
 from pytket.placement import NoiseAwarePlacement
 from pytket.utils import prepare_circuit
@@ -101,6 +99,7 @@ from .config import QiskitConfig
 
 if TYPE_CHECKING:
     from qiskit_ibm_provider.ibm_backend import IBMBackend as _QiskIBMBackend  # type: ignore
+    from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 
 _DEBUG_HANDLE_PREFIX = "_MACHINE_DEBUG_"
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -88,6 +88,8 @@ from pytket.predicates import (
     MaxNQubitsPredicate,
     Predicate,
 )
+from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
+
 from pytket.extensions.qiskit.qiskit_convert import tk_to_qiskit, _tk_gate_set
 from pytket.architecture import FullyConnected
 from pytket.placement import NoiseAwarePlacement
@@ -99,7 +101,6 @@ from .config import QiskitConfig
 
 if TYPE_CHECKING:
     from qiskit_ibm_provider.ibm_backend import IBMBackend as _QiskIBMBackend  # type: ignore
-    from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 
 _DEBUG_HANDLE_PREFIX = "_MACHINE_DEBUG_"
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -392,7 +392,6 @@ class IBMQBackend(Backend):
         :return: Compilation pass guaranteeing required predicates.
         :rtype: BasePass
         """
-        backend_name = self._backend.name
         config: QasmBackendConfiguration = self._backend.configuration()
         props: BackendProperties = cast(BackendProperties, self._backend.properties())
         return IBMQBackend.default_compilation_pass_static(

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -32,6 +32,7 @@ from typing import (
 )
 from warnings import warn
 
+from qiskit.providers.models import QasmBackendConfiguration
 from qiskit_ibm_provider import IBMProvider  # type: ignore
 from qiskit_ibm_provider.exceptions import IBMProviderError  # type: ignore
 from qiskit.primitives import SamplerResult  # type: ignore
@@ -55,11 +56,11 @@ from pytket.backends import Backend, CircuitNotRunError, CircuitStatus, ResultHa
 from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
 from pytket.backends.resulthandle import _ResultIdTuple
-from pytket.extensions.qiskit.qiskit_convert import (
+from ..qiskit_convert import (
     process_characterisation,
     get_avg_characterisation,
 )
-from pytket.extensions.qiskit._metadata import __extension_version__
+from .._metadata import __extension_version__
 from pytket.passes import (
     BasePass,
     auto_rebase_pass,
@@ -83,7 +84,7 @@ from pytket.predicates import (
     MaxNQubitsPredicate,
     Predicate,
 )
-from pytket.extensions.qiskit.qiskit_convert import tk_to_qiskit, _tk_gate_set
+from ..qiskit_convert import tk_to_qiskit, _tk_gate_set
 from pytket.architecture import FullyConnected
 from pytket.placement import NoiseAwarePlacement
 from pytket.utils import prepare_circuit
@@ -190,10 +191,10 @@ class IBMQBackend(Backend):
             else provider
         )
         self._backend: "_QiskIBMBackend" = self._provider.get_backend(backend_name)
-        config = self._backend.configuration()
+        config: QasmBackendConfiguration = self._backend.configuration()
         self._max_per_job = getattr(config, "max_experiments", 1)
 
-        gate_set = _tk_gate_set(self._backend)
+        gate_set = _tk_gate_set(config)
         self._backend_info = self._get_backend_info(self._backend)
 
         self._service = QiskitRuntimeService(
@@ -270,7 +271,7 @@ class IBMQBackend(Backend):
             hasattr(config, "supported_instructions")
             and "reset" in config.supported_instructions
         )
-        gate_set = _tk_gate_set(backend)
+        gate_set = _tk_gate_set(config)
         backend_info = BackendInfo(
             cls.__name__,
             backend.name,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -873,8 +873,24 @@ def process_characterisation(backend: "QiskitBackend") -> Dict[str, Any]:
     """
 
     # TODO explicitly check for and separate 1 and 2 qubit gates
-    properties = cast("BackendProperties", backend.properties())
+    config = backend.configuration()
+    props = cast(BackendProperties, backend.properties())
+    return process_characterisation_from_config(config, props)
 
+
+def process_characterisation_from_config(
+    config: QasmBackendConfiguration, properties: BackendProperties
+) -> Dict[str, Any]:
+    """Convert a :py:class:`qiskit.providers.backend.Backendv1` to a dictionary
+     containing device Characteristics
+
+    :param backend: A backend to be converted
+    :type backend: Backendv1
+    :return: A dictionary containing device characteristics
+    :rtype: dict
+    """
+
+    # TODO explicitly check for and separate 1 and 2 qubit gates
     def return_value_if_found(iterator: Iterable["Nduv"], name: str) -> Optional[Any]:
         try:
             first_found = next(filter(lambda item: item.name == name, iterator))
@@ -884,7 +900,6 @@ def process_characterisation(backend: "QiskitBackend") -> Dict[str, Any]:
             return first_found.value
         return None
 
-    config = backend.configuration()
     coupling_map = config.coupling_map
     n_qubits = config.n_qubits
     if coupling_map is None:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -35,7 +35,7 @@ from uuid import UUID
 
 import numpy as np
 
-from qiskit.providers.models import BackendConfiguration, QasmBackendConfiguration
+from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 import sympy
 import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore
 from qiskit import (

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -35,6 +35,7 @@ from uuid import UUID
 
 import numpy as np
 
+from qiskit.providers.models import BackendConfiguration, QasmBackendConfiguration
 import sympy
 import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore
 from qiskit import (
@@ -208,9 +209,8 @@ _gate_str_2_optype_rev = {v: k for k, v in _gate_str_2_optype.items()}
 _gate_str_2_optype_rev[OpType.Unitary1qBox] = "unitary"
 
 
-def _tk_gate_set(backend: "QiskitBackend") -> Set[OpType]:
+def _tk_gate_set(config: QasmBackendConfiguration) -> Set[OpType]:
     """Set of tket gate types supported by the qiskit backend"""
-    config = backend.configuration()
     if config.simulator:
         gate_set = {
             _gate_str_2_optype[gate_str]

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -81,6 +81,7 @@ from pytket.unit_id import _TEMP_BIT_NAME
 from pytket.pauli import Pauli, QubitPauliString
 from pytket.architecture import Architecture, FullyConnected
 from pytket.utils import QubitPauliOperator, gen_term_sequence_circuit
+from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 
 from pytket.passes import RebaseCustom
 
@@ -89,7 +90,6 @@ if TYPE_CHECKING:
     from qiskit.providers.models.backendproperties import Nduv  # type: ignore
     from qiskit.circuit.quantumcircuitdata import QuantumCircuitData  # type: ignore
     from pytket.circuit import Op, UnitID
-    from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 
 _qiskit_gates_1q = {
     # Exact equivalents (same signature except for factor of pi in each parameter):

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -35,7 +35,6 @@ from uuid import UUID
 
 import numpy as np
 
-from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 import sympy
 import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore
 from qiskit import (
@@ -87,12 +86,10 @@ from pytket.passes import RebaseCustom
 
 if TYPE_CHECKING:
     from qiskit.providers.backend import BackendV1 as QiskitBackend  # type: ignore
-    from qiskit.providers.models.backendproperties import (  # type: ignore
-        BackendProperties,
-        Nduv,
-    )
+    from qiskit.providers.models.backendproperties import Nduv  # type: ignore
     from qiskit.circuit.quantumcircuitdata import QuantumCircuitData  # type: ignore
     from pytket.circuit import Op, UnitID
+    from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
 
 _qiskit_gates_1q = {
     # Exact equivalents (same signature except for factor of pi in each parameter):


### PR DESCRIPTION
# Description

Add alternative to `default_compilation_pass` called `default_compilation_pass_static` that takes a `QasmBackendConfiguration` and a `BackendProperties` but does not reach out to the network or require authentication. In short, this PR enables offline compilation.

The general strategy was to write several 'shadow' methods that require fewer arguments than there preexisting counterparts. Then the preexisting methods were factored through the new methods without changing the preexisting type signatures.

Have tested the new methods in this branch manually by importing and testing them in the new Tierkreis code. Existing `pytket-qiskit` tests should test all new code paths as old methods now factor through the new methods.

To keep the number of shadow functions to a minimum, I've assumed that I can change the signatures of the methods starting with an underscore. If this is not the case then I can create shadow functions for these also.

# Summary of changes

* (Use relative imports to help my type checker.)
* `_tk_gate_set` now only requires config and not the whole backend.
* `_get_backend_info` now only requires config and properties and not the whole backend.
* `default_compilation_pass` now deconstructs `self` into arguments for a new static method `default_compilation_pass_static`, which may be called without instantiating a `IBMQBackend`.
* `rebase_pass` also calls into a new method `rebase_pass_static`, which can be called in the static context.
* Since `process_characterisation` is exposed by the library, we introduce a shadow method `process_characterisation_from_config`, which can be called in the static context.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
