### PR TITLE
Use QiskitRuntimeService instead of IBMProvider

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,7 @@ Unreleased
 * User can pass an `Options` instance (from `qiskit-ibm-runtime`)
   via a keyword argument to both an `IBMQBackend` constructor and 
   an instance method `IBMQBackend.process_circuits`.
+* Remove dependency on deprecated qiskit-ibm-provider.
 
 0.53.0 (April 2024)
 -------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -88,10 +88,8 @@ to disk:
 
 ::
 
-    from qiskit_ibm_provider import IBMProvider
     from qiskit_ibm_runtime import QiskitRuntimeService
 
-    IBMProvider.save_account(token=ibm_token)
     QiskitRuntimeService.save_account(channel="ibm_quantum", token=ibm_token)
 
 To see which devices you can access you can use the ``available_devices`` method on the :py:class:`IBMQBackend`. Note that it is possible to pass optional ``instance`` and ``provider`` arguments to this method. This allows you to see which devices are accessible through your IBM hub.

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -23,8 +23,7 @@ from typing import (
 )
 
 from qiskit_aer.noise.noise_model import NoiseModel  # type: ignore
-
-from qiskit_ibm_provider import IBMProvider  # type: ignore
+from qiskit_ibm_runtime import QiskitRuntimeService  # type: ignore
 
 from pytket.backends import (
     Backend,
@@ -60,14 +59,14 @@ class IBMQEmulatorBackend(Backend):
         self,
         backend_name: str,
         instance: Optional[str] = None,
-        provider: Optional["IBMProvider"] = None,
+        service: Optional["QiskitRuntimeService"] = None,
         token: Optional[str] = None,
     ):
         super().__init__()
         self._ibmq = IBMQBackend(
             backend_name=backend_name,
             instance=instance,
-            provider=provider,
+            service=service,
             token=token,
         )
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -87,7 +87,7 @@ from qiskit.providers.models import BackendProperties, QasmBackendConfiguration 
 from pytket.passes import RebaseCustom
 
 if TYPE_CHECKING:
-    from qiskit.providers.backend import BackendV1 as QiskitBackend  # type: ignore
+    from qiskit.providers.backend import BackendV1  # type: ignore
     from qiskit.providers.models.backendproperties import Nduv  # type: ignore
     from qiskit.circuit.quantumcircuitdata import QuantumCircuitData  # type: ignore
     from pytket.circuit import Op, UnitID
@@ -860,12 +860,12 @@ def tk_to_qiskit(
     return qcirc
 
 
-def process_characterisation(backend: "QiskitBackend") -> Dict[str, Any]:
-    """Convert a :py:class:`qiskit.providers.backend.Backendv1` to a dictionary
+def process_characterisation(backend: "BackendV1") -> Dict[str, Any]:
+    """Convert a :py:class:`qiskit.providers.backend.BackendV1` to a dictionary
      containing device Characteristics
 
     :param backend: A backend to be converted
-    :type backend: Backendv1
+    :type backend: BackendV1
     :return: A dictionary containing device characteristics
     :rtype: dict
     """

--- a/pytket/extensions/qiskit/tket_backend.py
+++ b/pytket/extensions/qiskit/tket_backend.py
@@ -14,7 +14,7 @@
 
 from typing import Optional, List, Union, Any
 from qiskit.circuit.quantumcircuit import QuantumCircuit  # type: ignore
-from qiskit.providers.backend import BackendV1 as QiskitBackend  # type: ignore
+from qiskit.providers.backend import BackendV1  # type: ignore
 from qiskit.providers.models import QasmBackendConfiguration  # type: ignore
 from qiskit.providers import Options  # type: ignore
 from pytket.extensions.qiskit import AerStateBackend, AerUnitaryBackend
@@ -41,7 +41,7 @@ def _extract_basis_gates(backend: Backend) -> List[str]:
     return []
 
 
-class TketBackend(QiskitBackend):
+class TketBackend(BackendV1):
     """Wraps a :py:class:`Backend` as a :py:class:`qiskit.providers.BaseBackend` for use
     within the Qiskit software stack.
 

--- a/pytket/extensions/qiskit/tket_pass.py
+++ b/pytket/extensions/qiskit/tket_pass.py
@@ -17,8 +17,8 @@ from qiskit.dagcircuit import DAGCircuit  # type: ignore
 from qiskit.providers import BackendV1  # type: ignore
 from qiskit.transpiler.basepasses import TransformationPass, BasePass as qBasePass  # type: ignore
 from qiskit.converters import circuit_to_dag, dag_to_circuit  # type: ignore
-from qiskit_aer.aerprovider import AerProvider  # type: ignore # type: ignore
-from qiskit_ibm_provider import IBMProvider  # type: ignore
+from qiskit_aer.aerprovider import AerProvider  # type: ignore
+from qiskit_aer.backends import AerSimulator  # type: ignore
 
 
 from pytket.passes import BasePass
@@ -95,10 +95,8 @@ class TketAutoPass(TketPass):
         :param token: Authentication token to use the `QiskitRuntimeService`.
         :type token: Optional[str]
         """
-        if isinstance(backend._provider, AerProvider):
+        if isinstance(backend, AerSimulator):
             tk_backend = self._aer_backend_map[backend.name]()
-        elif isinstance(backend._provider, IBMProvider):
-            tk_backend = IBMQBackend(backend.name, token=token)
         else:
-            raise NotImplementedError("This backend provider is not supported.")
+            tk_backend = IBMQBackend(backend.name, token=token)
         super().__init__(tk_backend.default_compilation_pass(optimisation_level))

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
         "qiskit-algorithms ~= 0.3.0",
         "qiskit-ibm-runtime ~= 0.23.0",
         "qiskit-aer ~= 0.14.0",
-        "qiskit-ibm-provider ~= 0.10.0",
         "numpy",
     ],
     classifiers=[

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -30,9 +30,7 @@ from qiskit_aer.noise import ReadoutError  # type: ignore
 from qiskit_aer.noise.errors import depolarizing_error, pauli_error  # type: ignore
 from qiskit_ibm_runtime import QiskitRuntimeService, Session, Sampler  # type: ignore
 
-from qiskit_ibm_provider import IBMProvider  # type: ignore
 from qiskit_aer import Aer  # type: ignore
-from qiskit_ibm_provider.exceptions import IBMError  # type: ignore
 
 from pytket.circuit import (
     Circuit,
@@ -1133,24 +1131,17 @@ def test_postprocess_emu(brisbane_emulator_backend: IBMQEmulatorBackend) -> None
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
-def test_available_devices(ibm_provider: IBMProvider) -> None:
+def test_available_devices(qiskit_runtime_service: QiskitRuntimeService) -> None:
     backend_info_list = IBMQBackend.available_devices(instance="ibm-q/open/main")
     assert len(backend_info_list) > 0
 
-    # Check consistency with pytket-qiskit and qiskit provider
-    assert len(backend_info_list) == len(ibm_provider.backends())
+    # Check consistency with pytket-qiskit and qiskit runtime service
+    assert len(backend_info_list) == len(qiskit_runtime_service.backends())
 
-    backend_info_list = IBMQBackend.available_devices(provider=ibm_provider)
+    backend_info_list = IBMQBackend.available_devices(service=qiskit_runtime_service)
     assert len(backend_info_list) > 0
-
-    try:
-        backend_info_list = IBMQBackend.available_devices()
-        assert len(backend_info_list) > 0
-    except IBMError as e:
-        if "Max retries exceeded" in e.message:
-            warn("`IBMQBackend.available_devices()` timed out.")
-        else:
-            assert not f"Unexpected error: {e.message}"
+    backend_info_list = IBMQBackend.available_devices()
+    assert len(backend_info_list) > 0
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=10)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@
 import os
 import pytest
 
-from qiskit_ibm_provider import IBMProvider  # type: ignore
+from qiskit_ibm_runtime import QiskitRuntimeService  # type: ignore
 from pytket.extensions.qiskit import (
     IBMQBackend,
     IBMQEmulatorBackend,
@@ -30,13 +30,12 @@ def setup_qiskit_account() -> None:
         # to enable one using the token in the env variable:
         # PYTKET_REMOTE_QISKIT_TOKEN
         # Note: The IBMQ account will only be enabled for the current session
-        try:
-            IBMProvider()
-        except:
+        if not QiskitRuntimeService.saved_accounts():
             token = os.getenv("PYTKET_REMOTE_QISKIT_TOKEN")
             if token:
-                IBMProvider.save_account(token, overwrite=True)
-                IBMProvider()
+                QiskitRuntimeService.save_account(
+                    channel="ibm_quantum", token=token, overwrite=True
+                )
 
 
 @pytest.fixture(scope="module")
@@ -67,14 +66,16 @@ def brisbane_emulator_backend() -> IBMQEmulatorBackend:
 
 
 @pytest.fixture(scope="module")
-def ibm_provider() -> IBMProvider:
+def qiskit_runtime_service() -> QiskitRuntimeService:
     token = os.getenv("PYTKET_REMOTE_QISKIT_TOKEN")
 
     try:
-        return IBMProvider(instance="ibm-q/open/main")
+        return QiskitRuntimeService(channel="ibm_quantum", instance="ibm-q/open/main")
     except:
         token = os.getenv("PYTKET_REMOTE_QISKIT_TOKEN")
-        return IBMProvider(token=token, instance="ibm-q/open/main")
+        return QiskitRuntimeService(
+            channel="ibm_quantum", token=token, instance="ibm-q/open/main"
+        )
 
 
 @pytest.fixture(scope="module")

--- a/tests/qiskit_backend_test.py
+++ b/tests/qiskit_backend_test.py
@@ -24,7 +24,6 @@ from qiskit.providers import JobStatus  # type: ignore
 from qiskit_algorithms import Grover, AmplificationProblem, AlgorithmError  # type: ignore
 from qiskit_aer import Aer  # type: ignore
 from qiskit_ibm_runtime import QiskitRuntimeService, Session, Sampler  # type: ignore
-from qiskit_ibm_provider import IBMProvider  # type: ignore
 
 from pytket.extensions.qiskit import (
     AerBackend,
@@ -41,14 +40,6 @@ from .mock_pytket_backend import MockShotBackend
 skip_remote_tests: bool = os.getenv("PYTKET_RUN_REMOTE_TESTS") is None
 
 REASON = "PYTKET_RUN_REMOTE_TESTS not set (requires IBM configuration)"
-
-
-@pytest.fixture
-def provider() -> Optional["IBMProvider"]:
-    if skip_remote_tests:
-        return None
-    else:
-        return IBMProvider(instance="ibm-q")
 
 
 def circuit_gen(measure: bool = False) -> QuantumCircuit:


### PR DESCRIPTION
# Description

All the functionality from `IBMProvider` is now provided by `QiskitRuntimeService`.

# Related issues

Closes #325 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
