### PR TITLE
Eliminate all warnings from tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,10 +4,11 @@ Changelog
 Unreleased
 ----------
 
-* User can pass an `Options` instance (from `qiskit-ibm-runtime`)
+* User can pass a `SamplerOptions` instance (from `qiskit-ibm-runtime`)
   via a keyword argument to both an `IBMQBackend` constructor and 
   an instance method `IBMQBackend.process_circuits`.
 * Remove dependency on deprecated qiskit-ibm-provider.
+* Remove support for deprecated "ibmq_qasm_simulator" backend.
 
 0.53.0 (April 2024)
 -------------------

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -32,7 +32,7 @@ from typing import (
 )
 from warnings import warn
 
-from qiskit.primitives import PrimitiveResult, SamplerResult  # type: ignore
+from qiskit.primitives import SamplerResult  # type: ignore
 
 
 # RuntimeJob has no queue_position attribute, which is referenced
@@ -614,17 +614,11 @@ class IBMQBackend(Backend):
                         sleep(10)
 
                 res = job.result(timeout=kwargs.get("timeout", None))
-            if isinstance(res, SamplerResult):
-                for circ_index, (r, d) in enumerate(zip(res.quasi_dists, res.metadata)):
-                    self._ibm_res_cache[(jobid, circ_index)] = Counter(
-                        {n: int(0.5 + d["shots"] * p) for n, p in r.items()}
-                    )
-            else:
-                assert isinstance(res, PrimitiveResult)
-                for circ_index, r in enumerate(res):
-                    self._ibm_res_cache[(jobid, circ_index)] = Counter(
-                        r.data.c.get_int_counts()
-                    )
+            assert isinstance(res, SamplerResult)
+            for circ_index, (r, d) in enumerate(zip(res.quasi_dists, res.metadata)):
+                self._ibm_res_cache[(jobid, circ_index)] = Counter(
+                    {n: int(0.5 + d["shots"] * p) for n, p in r.items()}
+                )
 
         counts = self._ibm_res_cache[cache_key]  # Counter[int]
         # Convert to `OutcomeArray`:

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -28,7 +28,7 @@ from qiskit.circuit import Parameter  # type: ignore
 from qiskit_aer.noise.noise_model import NoiseModel  # type: ignore
 from qiskit_aer.noise import ReadoutError  # type: ignore
 from qiskit_aer.noise.errors import depolarizing_error, pauli_error  # type: ignore
-from qiskit_ibm_runtime import QiskitRuntimeService, Session, Sampler  # type: ignore
+from qiskit_ibm_runtime import QiskitRuntimeService, Session  # type: ignore
 
 from qiskit_aer import Aer  # type: ignore
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -937,22 +937,6 @@ def test_aer_expanded_gates() -> None:
 
 
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
-def test_remote_simulator(qasm_simulator_backend: IBMQBackend) -> None:
-    c = Circuit(3).CX(0, 1)
-    c.add_gate(OpType.ZZPhase, 0.1, [0, 1])
-    c.add_gate(OpType.CY, [0, 1])
-    c.add_gate(OpType.CCX, [0, 1, 2])
-    c.measure_all()
-
-    assert qasm_simulator_backend.valid_circuit(c)
-
-    assert (
-        sum(qasm_simulator_backend.run_circuit(c, n_shots=10).get_counts().values())
-        == 10
-    )
-
-
-@pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_ibmq_mid_measure(brisbane_backend: IBMQBackend) -> None:
     c = Circuit(3, 3).H(1).CX(1, 2).Measure(0, 0).Measure(1, 1)
     c.add_barrier([0, 1, 2])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,15 +48,6 @@ def brisbane_backend() -> IBMQBackend:
 
 
 @pytest.fixture(scope="module")
-def qasm_simulator_backend() -> IBMQBackend:
-    return IBMQBackend(
-        "ibmq_qasm_simulator",
-        instance="ibm-q/open/main",
-        token=os.getenv("PYTKET_REMOTE_QISKIT_TOKEN"),
-    )
-
-
-@pytest.fixture(scope="module")
 def brisbane_emulator_backend() -> IBMQEmulatorBackend:
     return IBMQEmulatorBackend(
         "ibm_brisbane",

--- a/tests/qiskit_backend_test.py
+++ b/tests/qiskit_backend_test.py
@@ -122,28 +122,6 @@ def test_qiskit_counts(brisbane_emulator_backend: IBMQEmulatorBackend) -> None:
     assert all(n in range(4) for n in res.quasi_dists[0].keys())
 
 
-# https://github.com/CQCL/pytket-qiskit/issues/272
-@pytest.mark.xfail(reason="Qiskit sampler not working")
-@pytest.mark.skipif(skip_remote_tests, reason=REASON)
-def test_qiskit_counts_0() -> None:
-    num_qubits = 32
-    qc = QuantumCircuit(num_qubits)
-    qc.h(0)
-    qc.cx(0, 1)
-    qc.measure_all()
-
-    _service = QiskitRuntimeService(
-        channel="ibm_quantum",
-        instance="ibm-q/open/main",
-        token=os.getenv("PYTKET_REMOTE_QISKIT_TOKEN"),
-    )
-    _session = Session(service=_service, backend="ibmq_qasm_simulator")
-
-    sampler = SamplerV2(session=_session)
-    job = sampler.run([qc])
-    job.result()
-
-
 def test_architectures() -> None:
     # https://github.com/CQCL/pytket-qiskit/issues/14
     arch_list = [None, Architecture([(0, 1), (1, 2)]), FullyConnected(3)]

--- a/tests/qiskit_backend_test.py
+++ b/tests/qiskit_backend_test.py
@@ -23,7 +23,7 @@ from qiskit.primitives import BackendSampler  # type: ignore
 from qiskit.providers import JobStatus  # type: ignore
 from qiskit_algorithms import Grover, AmplificationProblem, AlgorithmError  # type: ignore
 from qiskit_aer import Aer  # type: ignore
-from qiskit_ibm_runtime import QiskitRuntimeService, Session, Sampler  # type: ignore
+from qiskit_ibm_runtime import QiskitRuntimeService, Session, SamplerV2  # type: ignore
 
 from pytket.extensions.qiskit import (
     AerBackend,
@@ -139,8 +139,8 @@ def test_qiskit_counts_0() -> None:
     )
     _session = Session(service=_service, backend="ibmq_qasm_simulator")
 
-    sampler = Sampler(session=_session)
-    job = sampler.run(circuits=qc)
+    sampler = SamplerV2(session=_session)
+    job = sampler.run([qc])
     job.result()
 
 

--- a/tests/qiskit_backend_test.py
+++ b/tests/qiskit_backend_test.py
@@ -103,8 +103,6 @@ def test_cancel() -> None:
     assert job.status() in [JobStatus.CANCELLED, JobStatus.DONE]
 
 
-# https://github.com/CQCL/pytket-qiskit/issues/272
-@pytest.mark.xfail(reason="Qiskit sampler not working")
 @pytest.mark.skipif(skip_remote_tests, reason=REASON)
 def test_qiskit_counts(brisbane_emulator_backend: IBMQEmulatorBackend) -> None:
     num_qubits = 2
@@ -113,7 +111,14 @@ def test_qiskit_counts(brisbane_emulator_backend: IBMQEmulatorBackend) -> None:
     qc.cx(0, 1)
     qc.measure_all()
 
-    s = BackendSampler(TketBackend(brisbane_emulator_backend))
+    s = BackendSampler(
+        TketBackend(
+            brisbane_emulator_backend,
+            comp_pass=brisbane_emulator_backend.default_compilation_pass(
+                optimisation_level=0
+            ),
+        )
+    )
 
     job = s.run([qc], shots=10)
     res = job.result()

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -802,7 +802,6 @@ def test_rebased_conversion() -> None:
     assert compare_unitaries(u1, u2)
 
 
-# https://github.com/CQCL/pytket-qiskit/issues/24
 @pytest.mark.xfail(reason="PauliEvolutionGate with symbolic parameter not supported")
 def test_parametrized_evolution() -> None:
     operator = SparsePauliOp(["XXZ", "YXY"], coeffs=[1.0, 0.5]) * Parameter("x")

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -1,4 +1,5 @@
 pytest
+pytest-timeout
 pytest-rerunfailures
 hypothesis
 requests_mock


### PR DESCRIPTION
# Description

The main change is to migrate from `SamplerV1` to `SamplerV2`. One implication is replacing the `options` parameter to `IBMQBackend.process_circuits()` with a `sampler_options` parameter (of a different type).

Also significant is removal of support for the "ibmq_qasm_simulator" backend, which is due to be retired on 15 May 2024.

I haven't done the migration from `BackendV1` to `BackendV2` because `BackendV1` is not (yet) deprecated.

Fixed and re-enabled one test.

# Related issues

Closes #19 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
