### PR TITLE
Forbid circuits with incomplete classical registers in tk_to_qiskit()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ Unreleased
   an instance method `IBMQBackend.process_circuits`.
 * Remove dependency on deprecated qiskit-ibm-provider.
 * Remove support for deprecated "ibmq_qasm_simulator" backend.
+* Forbid circuits with incomplete classical registers in ``tk_to_qiskit()``.
 
 0.53.0 (April 2024)
 -------------------

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1114,3 +1114,11 @@ def test_symbolic_param_conv() -> None:
             for i in range(len(qc_transpiled_again.parameters))
         }
     )
+
+
+# https://github.com/CQCL/pytket-qiskit/issues/337
+def test_nonregister_bits() -> None:
+    c = Circuit(1).X(0).measure_all()
+    c.rename_units({Bit(0): Bit(1)})
+    with pytest.raises(NotImplementedError):
+        tk_to_qiskit(c)


### PR DESCRIPTION
# Description

Qiskit circuits can only contain qubits and bits that are singly indexed in a contiguous manner starting from 0. Currently we just create registers large enough to contain the highest index in the pytket circuit. This is OK for qubits but for bits it causes incorrect results. The simplest fix is just to disallow this (rare) case.

# Related issues

Fixes #337 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
