### PR TITLE
Don't error if more than one "aer_simulator" backend is available

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,8 @@ Unreleased
 * Remove dependency on deprecated qiskit-ibm-provider.
 * Remove support for deprecated "ibmq_qasm_simulator" backend.
 * Forbid circuits with incomplete classical registers in ``tk_to_qiskit()``.
+* When constructing an Aer backend with a name for which more than one is
+  available, emit a warning and pick the first in the list.
 
 0.53.0 (April 2024)
 -------------------

--- a/pytket/extensions/qiskit/backends/__init__.py
+++ b/pytket/extensions/qiskit/backends/__init__.py
@@ -14,5 +14,5 @@
 """Backends for connecting to IBM devices and simulators directly from pytket"""
 
 from .ibm import IBMQBackend, NoIBMQCredentialsError
-from .aer import AerBackend, AerStateBackend, AerUnitaryBackend
+from .aer import AerBackend, AerStateBackend, AerUnitaryBackend, qiskit_aer_backend
 from .ibmq_emulator import IBMQEmulatorBackend

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -146,6 +146,9 @@ class _AerBaseBackend(Backend):
             self._backend_info.gate_set,
         )
 
+    def set_backend(self, backend_name: str) -> None:
+        self._qiskit_backend = Aer.get_backend(backend_name)
+
     def _arch_dependent_default_compilation_pass(
         self,
         arch: Architecture,
@@ -502,9 +505,7 @@ class AerBackend(_AerBaseBackend):
         n_qubits: int = 40,
     ):
         super().__init__()
-        self._qiskit_backend: "QiskitAerBackend" = Aer.get_backend(
-            self._qiskit_backend_name
-        )
+        self.set_backend(self._qiskit_backend_name)
         self._qiskit_backend.set_options(method=simulation_method)
         gate_set = _tket_gate_set_from_qiskit_backend(self._qiskit_backend).union(
             self._allowed_special_gates
@@ -592,9 +593,7 @@ class AerStateBackend(_AerBaseBackend):
         n_qubits: int = 40,
     ) -> None:
         super().__init__()
-        self._qiskit_backend: "QiskitAerBackend" = Aer.get_backend(
-            self._qiskit_backend_name
-        )
+        self.set_backend(self._qiskit_backend_name)
         self._backend_info = BackendInfo(
             name=type(self).__name__,
             device_name=self._qiskit_backend_name,
@@ -628,9 +627,7 @@ class AerUnitaryBackend(_AerBaseBackend):
 
     def __init__(self, n_qubits: int = 40) -> None:
         super().__init__()
-        self._qiskit_backend: "QiskitAerBackend" = Aer.get_backend(
-            self._qiskit_backend_name
-        )
+        self.set_backend(self._qiskit_backend_name)
         self._backend_info = BackendInfo(
             name=type(self).__name__,
             device_name=self._qiskit_backend_name,

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -28,6 +28,7 @@ from typing import (
     TYPE_CHECKING,
     Set,
 )
+import warnings
 
 import numpy as np
 from qiskit import transpile  # type: ignore
@@ -93,9 +94,9 @@ def _default_q_index(q: Qubit) -> int:
 
 
 def _tket_gate_set_from_qiskit_backend(
-    qiskit_backend: "QiskitAerBackend",
+    qiskit_aer_backend: "QiskitAerBackend",
 ) -> Set[OpType]:
-    config = qiskit_backend.configuration()
+    config = qiskit_aer_backend.configuration()
     gate_set = {
         _gate_str_2_optype[gate_str]
         for gate_str in config.basis_gates
@@ -116,6 +117,23 @@ def _tket_gate_set_from_qiskit_backend(
     # special case mapping TK1 to U
     gate_set.add(OpType.TK1)
     return gate_set
+
+
+def qiskit_aer_backend(backend_name: str) -> "QiskitAerBackend":
+    """Find a qiskit backend with the given name.
+
+    If more than one backend with the given name is available, emit a warning
+    and return the first one in the list returned by `Aer.backends()`.
+    """
+    candidates = [b for b in Aer.backends() if b.name == backend_name]
+    n_candidates = len(candidates)
+    if n_candidates == 0:
+        raise ValueError(f"No backend with name '{backend_name}' is available.")
+    if n_candidates > 1:
+        warnings.warn(
+            f"More than one backend with name '{backend_name}' is available. Picking one."
+        )
+    return candidates[0]
 
 
 class _AerBaseBackend(Backend):
@@ -145,9 +163,6 @@ class _AerBaseBackend(Backend):
         return auto_rebase_pass(
             self._backend_info.gate_set,
         )
-
-    def set_backend(self, backend_name: str) -> None:
-        self._qiskit_backend = Aer.get_backend(backend_name)
 
     def _arch_dependent_default_compilation_pass(
         self,
@@ -505,7 +520,7 @@ class AerBackend(_AerBaseBackend):
         n_qubits: int = 40,
     ):
         super().__init__()
-        self.set_backend(self._qiskit_backend_name)
+        self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)
         self._qiskit_backend.set_options(method=simulation_method)
         gate_set = _tket_gate_set_from_qiskit_backend(self._qiskit_backend).union(
             self._allowed_special_gates
@@ -593,7 +608,7 @@ class AerStateBackend(_AerBaseBackend):
         n_qubits: int = 40,
     ) -> None:
         super().__init__()
-        self.set_backend(self._qiskit_backend_name)
+        self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)
         self._backend_info = BackendInfo(
             name=type(self).__name__,
             device_name=self._qiskit_backend_name,
@@ -627,7 +642,7 @@ class AerUnitaryBackend(_AerBaseBackend):
 
     def __init__(self, n_qubits: int = 40) -> None:
         super().__init__()
-        self.set_backend(self._qiskit_backend_name)
+        self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)
         self._backend_info = BackendInfo(
             name=type(self).__name__,
             device_name=self._qiskit_backend_name,

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -35,7 +35,6 @@ from qiskit.transpiler.passes import BasisTranslator  # type: ignore
 from qiskit.circuit.equivalence_library import StandardEquivalenceLibrary  # type: ignore
 from qiskit_ibm_runtime.fake_provider import FakeGuadalupe  # type: ignore
 from qiskit.circuit.parameterexpression import ParameterExpression  # type: ignore
-from pytket.extensions.qiskit import qiskit_to_tk, tk_to_qiskit
 from qiskit.circuit.library import TwoLocal
 from qiskit import transpile
 
@@ -53,6 +52,7 @@ from pytket.circuit import (
     StatePreparationBox,
 )
 from pytket.extensions.qiskit import tk_to_qiskit, qiskit_to_tk, IBMQBackend
+from pytket.extensions.qiskit.backends import qiskit_aer_backend
 from pytket.extensions.qiskit.qiskit_convert import _gate_str_2_optype
 from pytket.extensions.qiskit.tket_pass import TketPass, TketAutoPass
 from pytket.extensions.qiskit.result_convert import qiskit_result_to_backendresult
@@ -238,7 +238,7 @@ def test_symbolic() -> None:
 
 def test_measures() -> None:
     qc = get_test_circuit(True)
-    backend = Aer.get_backend("aer_simulator")
+    backend = qiskit_aer_backend("aer_simulator")
     qc = transpile(qc, backend)
     job = backend.run([qc], seed_simulator=7)
     counts0 = job.result().get_counts(qc)
@@ -374,7 +374,7 @@ def test_tketpass() -> None:
 def test_tketautopass(brisbane_backend: IBMQBackend) -> None:
     backends = [
         Aer.get_backend("aer_simulator_statevector"),
-        Aer.get_backend("aer_simulator"),
+        qiskit_aer_backend("aer_simulator"),
         Aer.get_backend("aer_simulator_unitary"),
     ]
     backends.append(brisbane_backend._backend)
@@ -559,7 +559,7 @@ def test_convert_result() -> None:
     qc.measure(qr1[0], cr[0])
     qc.measure(qr2[1], cr2[0])
 
-    simulator = Aer.get_backend("aer_simulator")
+    simulator = qiskit_aer_backend("aer_simulator")
     qisk_result = simulator.run(qc, shots=10).result()
 
     tk_res = next(qiskit_result_to_backendresult(qisk_result))


### PR DESCRIPTION
# Description

When both qiskit-aer and qiskit-aer-gpu are installed, there are two Aer backend with the name "aer_simulator".

Tested locally with and without the qiskit-aer-gpu package.

# Related issues

Fixes #352 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
