### PR TITLE
Remove upper caps on dependency versions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,12 +44,12 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.29",
-        "qiskit ~= 1.1",
-        "qiskit-algorithms ~= 0.3.0",
-        "qiskit-ibm-runtime ~= 0.24.1",
-        "qiskit-aer ~= 0.14.2",
-        "numpy < 2",
+        "pytket >= 1.29",
+        "qiskit >= 1.1",
+        "qiskit-algorithms >= 0.3.0",
+        "qiskit-ibm-runtime >= 0.24.1",
+        "qiskit-aer >= 0.14.2",
+        "numpy >= 1.26.4",
     ],
     classifiers=[
         "Environment :: Console",


### PR DESCRIPTION
See discussion in #351 .

Closes #351 .
