### PR TITLE
Update ibm.py to enable execution on IBM QPUs

### DIFF
--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -619,9 +619,9 @@ class IBMQBackend(Backend):
                 if self._monitor and job:
                     #     job_monitor(job)
                     status = job.status()
-                    while status.name not in ["DONE", "CANCELLED", "ERROR"]:
+                    while status not in ["DONE", "CANCELLED", "ERROR"]:
                         status = job.status()
-                        print("Job status is", status.name)
+                        print("Job status is", status)
                         sleep(10)
 
                 res = job.result(timeout=kwargs.get("timeout", None))


### PR DESCRIPTION
`status` has no attribute `name` for IBMQ QPUs (e.g. ibm_brisbane) such that an `AttributeError` occurs when executing on e.g. ibm_brisbane. 

_Note:_  This is not a problem for the AerSimulator, such that the tests are still working.