### PR TITLE
fix: Allow circuits containing CnZ gates to run on `AerBackend`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ Unreleased
 * Add conversion of controlled unitary gates from qiskit to tket.
 * Initialize `TketAutoPass` with a `BackendV2`.
 * Update `TketBackend` to derive from `BackendV2`.
-* Fix to allow `AerBackend` to work with multi-controlled Y and Z gates.
+* Fix to allow `AerBackend` to work with multi-controlled Z gates.
 
 0.55.0 (July 2024)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ Unreleased
 * Add conversion of controlled unitary gates from qiskit to tket.
 * Initialize `TketAutoPass` with a `BackendV2`.
 * Update `TketBackend` to derive from `BackendV2`.
+* Fix to allow `AerBackend` to work with multi-controlled Y and Z gates.
 
 0.55.0 (July 2024)
 ------------------

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -700,13 +700,9 @@ order or only one bit of one register"""
     if optype == OpType.CnX:
         return qcirc.mcx(qargs[:-1], qargs[-1])
     if optype == OpType.CnY:
-        qcirc.s(qargs[-1])
-        qcirc.mcx(qargs[:-1], qargs[-1])
-        return qcirc.sdg(qargs[-1])
+        return qcirc.append(qiskit_gates.YGate().control(len(qargs) - 1), qargs)
     if optype == OpType.CnZ:
-        qcirc.h(qargs[-1])
-        qcirc.mcx(qargs[:-1], qargs[-1])
-        return qcirc.h(qargs[-1])
+        return qcirc.append(qiskit_gates.ZGate().control(len(qargs) - 1), qargs)
     if optype == OpType.CnRy:
         # might as well do a bit more checking
         assert len(op.params) == 1

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -700,9 +700,13 @@ order or only one bit of one register"""
     if optype == OpType.CnX:
         return qcirc.mcx(qargs[:-1], qargs[-1])
     if optype == OpType.CnY:
-        return qcirc.append(qiskit_gates.YGate().control(len(qargs) - 1), qargs)
+        qcirc.s(qargs[-1])
+        qcirc.mcx(qargs[:-1], qargs[-1])
+        return qcirc.sdg(qargs[-1])
     if optype == OpType.CnZ:
-        return qcirc.append(qiskit_gates.ZGate().control(len(qargs) - 1), qargs)
+        qcirc.h(qargs[-1])
+        qcirc.mcx(qargs[:-1], qargs[-1])
+        return qcirc.h(qargs[-1])
     if optype == OpType.CnRy:
         # might as well do a bit more checking
         assert len(op.params) == 1

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -700,13 +700,11 @@ order or only one bit of one register"""
     if optype == OpType.CnX:
         return qcirc.mcx(qargs[:-1], qargs[-1])
     if optype == OpType.CnY:
-        qcirc.s(qargs[-1])
-        qcirc.mcx(qargs[:-1], qargs[-1])
-        return qcirc.sdg(qargs[-1])
+        return qcirc.append(qiskit_gates.YGate().control(len(qargs) - 1), qargs)
     if optype == OpType.CnZ:
-        qcirc.h(qargs[-1])
-        qcirc.mcx(qargs[:-1], qargs[-1])
-        return qcirc.h(qargs[-1])
+        new_gate = qiskit_gates.ZGate().control(len(qargs) - 1)
+        new_gate.name = "mcz"
+        return qcirc.append(new_gate, qargs)
     if optype == OpType.CnRy:
         # might as well do a bit more checking
         assert len(op.params) == 1

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1432,7 +1432,7 @@ def test_ibmq_local_emulator(
     assert sum(c0 != c1 for c0, c1 in counts) < 25
 
 
-def text_mc_gate_on_aer() -> None:
+def test_mc_gate_on_aer() -> None:
     """Test for cm gates support in aer simulators
     https://github.com/CQCL/pytket-qiskit/issues/368"""
     for b in [AerBackend(), AerStateBackend(), AerUnitaryBackend()]:

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1430,3 +1430,21 @@ def test_ibmq_local_emulator(
     counts = r.get_counts()
     # Most results should be (0,0) or (1,1):
     assert sum(c0 != c1 for c0, c1 in counts) < 25
+
+
+def text_mc_gate_on_aer() -> None:
+    """Test for cm gates support in aer simulators
+    https://github.com/CQCL/pytket-qiskit/issues/368"""
+    for b in [AerBackend(), AerStateBackend(), AerUnitaryBackend()]:
+        for i in range(3):
+            circ = Circuit(4)
+            circ.add_gate(OpType.CnX, range(4))
+            circ.add_gate(OpType.CnY, range(4))
+            circ.add_gate(OpType.CnZ, range(4))
+            circ.add_gate(OpType.CnRy, 0.5, range(4))
+            unitary_before = circ.get_unitary()
+            compilation_pass = b.default_compilation_pass(i)
+            compilation_pass.apply(circ)
+            unitary_after = circ.get_unitary()
+            assert compare_unitaries(unitary_before, unitary_after)
+            b.run_circuit(circ, n_shots=10)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1503,16 +1503,12 @@ def test_noisy_density_matrix_simulation() -> None:
 def test_mc_gate_on_aer() -> None:
     """Test for cm gates support in aer simulators
     https://github.com/CQCL/pytket-qiskit/issues/368"""
-    for b in [AerBackend(), AerStateBackend(), AerUnitaryBackend()]:
-        for i in range(3):
-            circ = Circuit(4)
-            circ.add_gate(OpType.CnX, range(4))
-            circ.add_gate(OpType.CnY, range(4))
-            circ.add_gate(OpType.CnZ, range(4))
-            circ.add_gate(OpType.CnRy, 0.5, range(4))
-            unitary_before = circ.get_unitary()
-            compilation_pass = b.default_compilation_pass(i)
-            compilation_pass.apply(circ)
-            unitary_after = circ.get_unitary()
-            assert compare_unitaries(unitary_before, unitary_after)
-            b.run_circuit(circ, n_shots=10)
+    b = AerBackend()
+    c = Circuit(3, 3)
+    c.X(0).X(1)
+    c.H(2)
+    c.add_gate(OpType.CnZ, [0, 1, 2])
+    c.H(2)
+    c.measure_all()
+    r = b.run_circuit(c, n_shots=10)
+    assert r.get_counts() == Counter({(1, 1, 1): 10})

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -829,7 +829,7 @@ def test_multicontrolled_gate_conversion() -> None:
     assert my_tkc.n_gates_of_type(OpType.CnRy) == 2
     my_new_qc = tk_to_qiskit(my_tkc)
     qiskit_ops = my_new_qc.count_ops()
-    assert qiskit_ops["c3y"] and qiskit_ops["c3z"] and qiskit_ops["c3ry"] == 2
+    assert qiskit_ops["c3y"] and qiskit_ops["mcz"] and qiskit_ops["c3ry"] == 2
     tcirc = qiskit_to_tk(my_new_qc)
     unitary_after = tcirc.get_unitary()
     assert compare_unitaries(unitary_before, unitary_after)
@@ -1024,7 +1024,7 @@ def test_ccz_conversion() -> None:
     assert tkc_ccz.n_gates_of_type(OpType.CnZ) == tkc_ccz.n_gates == 2
     # bidirectional CnZ conversion already supported
     qc_ccz2 = tk_to_qiskit(tkc_ccz)
-    assert qc_ccz2.count_ops()["ccz"] == 2
+    assert qc_ccz2.count_ops()["mcz"] == 2
     tkc_ccz2 = qiskit_to_tk(qc_ccz2)
     assert compare_unitaries(tkc_ccz.get_unitary(), tkc_ccz2.get_unitary())
 


### PR DESCRIPTION
# Description
Replace CnY and CnZ in qiskit gates
https://github.com/CQCL/pytket-qiskit/commit/519a5123e4c0a4ff93c7077b3cb2f827522ebe87?diff=split&w=1

Make a test function
https://github.com/CQCL/pytket-qiskit/commit/94128565c8edfa5a8fd461459f315932f4299cb9?diff=split&w=0

# Related issues

https://github.com/CQCL/pytket-qiskit/issues/368

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
