### PR TITLE
Fix symbol conversion into qiskit

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Fix conversion of symbols into qiskit.
+* Require qiskit >= 1.2.0.
 
 0.55.0 (July 2024)
 ------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Fix conversion of symbols into qiskit.
+
 0.55.0 (July 2024)
 ------------------
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -35,7 +35,7 @@ from uuid import UUID
 
 import numpy as np
 from symengine import sympify  # type: ignore
-from symengine.lib import symengine_wrapper
+from symengine.lib import symengine_wrapper  # type: ignore
 
 import sympy
 import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -35,6 +35,7 @@ from uuid import UUID
 
 import numpy as np
 from symengine import sympify  # type: ignore
+from symengine.lib import symengine_wrapper
 
 import sympy
 import qiskit.circuit.library.standard_gates as qiskit_gates  # type: ignore
@@ -846,7 +847,9 @@ def tk_to_qiskit(
             # See Parameter.__init__() in qiskit/circuit/parameter.py.
             new_p = Parameter(p_name)
             new_p._uuid = uuid
-            new_p._parameter_keys = frozenset(((p_name, uuid),))
+            new_p._parameter_keys = frozenset(
+                ((symengine_wrapper.Symbol(p_name), uuid),)
+            )
             new_p._hash = hash((new_p._parameter_keys, new_p._symbol_expr))
             updates[p] = new_p
     qcirc.assign_parameters(updates, inplace=True)

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket >= 1.30.0",
-        "qiskit >= 1.1",
+        "qiskit >= 1.2.0",
         "qiskit-algorithms >= 0.3.0",
         "qiskit-ibm-runtime >= 0.24.1",
         "qiskit-aer >= 0.14.2",


### PR DESCRIPTION
# Description

Fix the conversion of symbols from pytket circuits to qiskit so that round-trip equality checks pass.

This needs qiskit >= 1.2.0 to work, so bump the minimum qiskit version.

# Related issues

Fixes #376 .

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
