### PR TITLE
Get rid of some deprecation warnings

### DIFF
--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -51,7 +51,7 @@ from pytket.passes import (
     FullPeepholeOptimise,
     SequencePass,
     SynthesiseTket,
-    auto_rebase_pass,
+    AutoRebase,
     NaivePlacementPass,
 )
 from pytket.pauli import Pauli, QubitPauliString
@@ -161,7 +161,7 @@ class _AerBaseBackend(Backend):
         return self._backend_info
 
     def rebase_pass(self) -> BasePass:
-        return auto_rebase_pass(
+        return AutoRebase(
             self._backend_info.gate_set,
         )
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -556,7 +556,7 @@ class IBMQBackend(Backend):
                             ppcirc_strs[i],
                         )
                 else:
-                    sampler = SamplerV2(session=self._session, options=sampler_options)
+                    sampler = SamplerV2(mode=self._session, options=sampler_options)
                     job = sampler.run(qcs, shots=n_shots)
                     job_id = job.job_id()
                     for i, ind in enumerate(indices_chunk):

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -204,7 +204,7 @@ class IBMQBackend(Backend):
         self._service = QiskitRuntimeService(
             channel="ibm_quantum", token=token, instance=instance
         )
-        self._session = Session(service=self._service, backend=backend_name)
+        self._session = Session(backend=self._backend)
 
         self._primitive_gates = _get_primitive_gates(gate_set)
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -193,7 +193,7 @@ class IBMQBackend(Backend):
             if service is None
             else service
         )
-        self._backend: "BackendV1" = self._service.get_backend(backend_name)
+        self._backend: "BackendV1" = self._service.backend(backend_name)
         config: QasmBackendConfiguration = self._backend.configuration()
         self._max_per_job = getattr(config, "max_experiments", 1)
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -57,7 +57,7 @@ from pytket.backends.backendresult import BackendResult
 from pytket.backends.resulthandle import _ResultIdTuple
 from pytket.passes import (
     BasePass,
-    auto_rebase_pass,
+    AutoRebase,
     KAKDecomposition,
     RemoveRedundancies,
     SequencePass,
@@ -476,7 +476,7 @@ class IBMQBackend(Backend):
 
     @staticmethod
     def rebase_pass_offline(primitive_gates: set[OpType]) -> BasePass:
-        return auto_rebase_pass(primitive_gates)
+        return AutoRebase(primitive_gates)
 
     def process_circuits(
         self,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -341,7 +341,8 @@ class CircuitBuilder:
         self, circuit: QuantumCircuit, data: Optional["QuantumCircuitData"] = None
     ) -> None:
         data = data or circuit.data
-        for instr, qargs, cargs in data:
+        for datum in data:
+            instr, qargs, cargs = datum.operation, datum.qubits, datum.clbits
             condition_kwargs = {}
             if instr.condition is not None:
                 if type(instr.condition[0]) == ClassicalRegister:

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -33,7 +33,7 @@ from qiskit.synthesis import SuzukiTrotter  # type: ignore
 from qiskit_aer import Aer  # type: ignore
 from qiskit.transpiler.passes import BasisTranslator  # type: ignore
 from qiskit.circuit.equivalence_library import StandardEquivalenceLibrary  # type: ignore
-from qiskit_ibm_runtime.fake_provider import FakeGuadalupe  # type: ignore
+from qiskit_ibm_runtime.fake_provider import FakeGuadalupeV2  # type: ignore
 from qiskit.circuit.parameterexpression import ParameterExpression  # type: ignore
 from qiskit.circuit.library import TwoLocal
 from qiskit import transpile
@@ -88,7 +88,7 @@ def _get_qiskit_statevector(qc: QuantumCircuit) -> np.ndarray:
 def test_parameterised_circuit_global_phase() -> None:
     pass_1 = BasisTranslator(
         StandardEquivalenceLibrary,
-        target_basis=FakeGuadalupe().configuration().basis_gates,
+        target_basis=FakeGuadalupeV2().configuration().basis_gates,
     )
     pass_2 = CliffordSimp()
 


### PR DESCRIPTION
These are the low-hanging fruit. The main change still to come is migration from `BackendV1` to `BackendV2`.