### PR TITLE
feat: add density matrix simulation via qiskit Aer

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,11 +31,6 @@ API documentation
     :inherited-members:
     :members:
 
-.. autoclass:: pytket.extensions.qiskit.AerDensityMatrixBackend
-    :special-members: __init__
-    :inherited-members:
-    :members:
-
 .. automodule:: pytket.extensions.qiskit
     :members: qiskit_to_tk, tk_to_qiskit, process_characterisation
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -26,6 +26,11 @@ API documentation
     :inherited-members:
     :members:
 
+.. autoclass:: pytket.extensions.qiskit.AerDensityMatrixBackend
+    :special-members: __init__
+    :inherited-members:
+    :members:
+
 .. automodule:: pytket.extensions.qiskit
     :members: qiskit_to_tk, tk_to_qiskit, process_characterisation
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,6 +31,11 @@ API documentation
     :inherited-members:
     :members:
 
+.. autoclass:: pytket.extensions.qiskit.AerDensityMatrixBackend
+    :special-members: __init__
+    :inherited-members:
+    :members:
+
 .. automodule:: pytket.extensions.qiskit
     :members: qiskit_to_tk, tk_to_qiskit, process_characterisation
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,9 +1,13 @@
 Changelog
 ~~~~~~~~~
 
+.. currentmodule:: pytket.extensions.qiskit
+
+
 Unreleased
 ----------
 
+* Added :py:class:`AerDensityMatrixBackend` simulator. This simulator has the option to support a :py:class:`NoiseModel`.
 * Fix conversion of symbols into qiskit.
 * Require qiskit >= 1.2.0.
 * Add conversion of controlled unitary gates from qiskit to tket.

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -32,6 +32,7 @@ Available IBM Backends
     AerBackend
     AerStateBackend
     AerUnitaryBackend
+    AerDensityMatrixBackend
 
 
 An example using the shots-based :py:class:`AerBackend` simulator is shown below. 

--- a/pytket/extensions/qiskit/__init__.py
+++ b/pytket/extensions/qiskit/__init__.py
@@ -21,6 +21,7 @@ from .backends import (
     AerBackend,
     AerStateBackend,
     AerUnitaryBackend,
+    AerDensityMatrixBackend,
     IBMQEmulatorBackend,
 )
 from .backends.config import set_ibmq_config

--- a/pytket/extensions/qiskit/backends/__init__.py
+++ b/pytket/extensions/qiskit/backends/__init__.py
@@ -14,5 +14,11 @@
 """Backends for connecting to IBM devices and simulators directly from pytket"""
 
 from .ibm import IBMQBackend, NoIBMQCredentialsError
-from .aer import AerBackend, AerStateBackend, AerUnitaryBackend, qiskit_aer_backend
+from .aer import (
+    AerBackend,
+    AerStateBackend,
+    AerUnitaryBackend,
+    AerDensityMatrixBackend,
+    qiskit_aer_backend,
+)
 from .ibmq_emulator import IBMQEmulatorBackend

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -694,7 +694,7 @@ class AerDensityMatrixBackend(_AerBaseBackend):
     ) -> None:
         super().__init__()
         self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)
-        self._noise_model = noise_model
+
         gate_set = _tket_gate_set_from_qiskit_backend(self._qiskit_backend).union(
             self._allowed_special_gates
         )

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -304,6 +304,8 @@ class _AerBaseBackend(Backend):
                     qc.save_state()
                 elif self.supports_unitary:
                     qc.save_unitary()
+                elif self.supports_density_matrix:
+                    qc.save_state()
                 qcs.append(qc)
                 tkc_qubits_count.append(c0.n_qubits)
                 ppcirc_strs.append(json.dumps(ppcirc_rep))
@@ -662,6 +664,7 @@ class AerUnitaryBackend(_AerBaseBackend):
 
 class AerDensityMatrixBackend(_AerBaseBackend):
     _supports_density_matrix = True
+    _supports_state = False
     _memory = False
     _noise_model = None
     _needs_transpile = True
@@ -669,21 +672,22 @@ class AerDensityMatrixBackend(_AerBaseBackend):
 
     _qiskit_backend_name = "aer_simulator_density_matrix"
 
-    def __init__(self, n_qubits: int = 40) -> None:
+    def __init__(
+        self, n_qubits: int = 40, noise_model: Optional[NoiseModel] = None
+    ) -> None:
         super().__init__()
         self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)
+        self._noise_model = noise_model
         self._backend_info = BackendInfo(
             name=type(self).__name__,
             device_name=self._qiskit_backend_name,
             version=__extension_version__,
             architecture=FullyConnected(n_qubits),
             gate_set=_tket_gate_set_from_qiskit_backend(self._qiskit_backend),
-            supports_midcircuit_measurement=True,  # is this correct?
+            supports_midcircuit_measurement=True,
             misc={"characterisation": None},
         )
         self._required_predicates = [
-            NoClassicalControlPredicate(),
-            NoFastFeedforwardPredicate(),
             GateSetPredicate(self._backend_info.gate_set),
         ]
 

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -695,14 +695,14 @@ class AerDensityMatrixBackend(_AerBaseBackend):
         super().__init__()
         self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)
 
-        gate_set = _tket_gate_set_from_qiskit_backend(self._qiskit_backend).union(
-            self._allowed_special_gates
-        )
+        gate_set: set[OpType] = _tket_gate_set_from_qiskit_backend(
+            self._qiskit_backend
+        ).union(self._allowed_special_gates)
         self._noise_model = _map_trivial_noise_model_to_none(noise_model)
-        characterisation = _get_characterisation_of_noise_model(
-            self._noise_model, gate_set
+        characterisation: NoiseModelCharacterisation = (
+            _get_characterisation_of_noise_model(self._noise_model, gate_set)
         )
-        self._has_arch = bool(characterisation.architecture) and bool(
+        self._has_arch: bool = bool(characterisation.architecture) and bool(
             characterisation.architecture.nodes
         )
 
@@ -710,7 +710,11 @@ class AerDensityMatrixBackend(_AerBaseBackend):
             name=type(self).__name__,
             device_name=self._qiskit_backend_name,
             version=__extension_version__,
-            architecture=FullyConnected(n_qubits),
+            architecture=(
+                FullyConnected(n_qubits)
+                if not self._has_arch
+                else characterisation.architecture
+            ),
             gate_set=_tket_gate_set_from_qiskit_backend(self._qiskit_backend),
             supports_midcircuit_measurement=True,
             supports_reset=True,

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -300,12 +300,12 @@ class _AerBaseBackend(Backend):
                     c0, ppcirc_rep = tkc, None
 
                 qc = tk_to_qiskit(c0, replace_implicit_swaps)
-                if self.supports_state:
+                if self.supports_state or self.supports_density_matrix:
                     qc.save_state()
+
                 elif self.supports_unitary:
                     qc.save_unitary()
-                elif self.supports_density_matrix:
-                    qc.save_state()
+
                 qcs.append(qc)
                 tkc_qubits_count.append(c0.n_qubits)
                 ppcirc_strs.append(json.dumps(ppcirc_rep))

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -301,8 +301,11 @@ class _AerBaseBackend(Backend):
 
                 qc = tk_to_qiskit(c0, replace_implicit_swaps)
 
-                if self.supports_state or self.supports_density_matrix:
+                if self.supports_state:
                     qc.save_state()
+
+                elif self.supports_density_matrix:
+                    qc.save_density_matrix()
 
                 elif self.supports_unitary:
                     qc.save_unitary()

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -300,6 +300,7 @@ class _AerBaseBackend(Backend):
                     c0, ppcirc_rep = tkc, None
 
                 qc = tk_to_qiskit(c0, replace_implicit_swaps)
+
                 if self.supports_state or self.supports_density_matrix:
                     qc.save_state()
 
@@ -680,7 +681,9 @@ class AerDensityMatrixBackend(_AerBaseBackend):
     _qiskit_backend_name = "aer_simulator_density_matrix"
 
     def __init__(
-        self, n_qubits: int = 40, noise_model: Optional[NoiseModel] = None
+        self,
+        noise_model: Optional[NoiseModel] = None,
+        n_qubits: int = 40,
     ) -> None:
         super().__init__()
         self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -663,6 +663,13 @@ class AerUnitaryBackend(_AerBaseBackend):
 
 
 class AerDensityMatrixBackend(_AerBaseBackend):
+    """
+    Backend for running simulations on the Qiskit Aer density matrix simulator.
+
+    :param noise_model: Noise model to apply during simulation. Defaults to None.
+    :param n_qubits: The maximum number of qubits supported by the backend.
+    """
+
     _supports_density_matrix = True
     _supports_state = False
     _memory = False

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -500,16 +500,16 @@ class AerBackend(_AerBaseBackend):
     :param n_qubits: The maximum number of qubits supported by the backend.
     """
 
-    _persistent_handles = False
-    _supports_shots = True
-    _supports_counts = True
-    _supports_expectation = True
-    _expectation_allows_nonhermitian = False
+    _persistent_handles: bool = False
+    _supports_shots: bool = True
+    _supports_counts: bool = True
+    _supports_expectation: bool = True
+    _expectation_allows_nonhermitian: bool = False
 
-    _memory = True
+    _memory: bool = True
 
-    _qiskit_backend_name = "aer_simulator"
-    _allowed_special_gates = {
+    _qiskit_backend_name: str = "aer_simulator"
+    _allowed_special_gates: set[OpType] = {
         OpType.Measure,
         OpType.Barrier,
         OpType.Reset,
@@ -526,9 +526,9 @@ class AerBackend(_AerBaseBackend):
         super().__init__()
         self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)
         self._qiskit_backend.set_options(method=simulation_method)
-        gate_set = _tket_gate_set_from_qiskit_backend(self._qiskit_backend).union(
-            self._allowed_special_gates
-        )
+        gate_set: set[OpType] = _tket_gate_set_from_qiskit_backend(
+            self._qiskit_backend
+        ).union(self._allowed_special_gates)
 
         self._crosstalk_params = crosstalk_params
         if self._crosstalk_params is not None:
@@ -597,15 +597,15 @@ class AerStateBackend(_AerBaseBackend):
     :param n_qubits: The maximum number of qubits supported by the backend.
     """
 
-    _persistent_handles = False
-    _supports_state = True
-    _supports_expectation = True
-    _expectation_allows_nonhermitian = False
+    _persistent_handles: bool = False
+    _supports_state: bool = True
+    _supports_expectation: bool = True
+    _expectation_allows_nonhermitian: bool = False
 
-    _noise_model = None
-    _memory = False
+    _noise_model: Optional[NoiseModel] = None
+    _memory: bool = False
 
-    _qiskit_backend_name = "aer_simulator_statevector"
+    _qiskit_backend_name: str = "aer_simulator_statevector"
 
     def __init__(
         self,
@@ -635,14 +635,14 @@ class AerUnitaryBackend(_AerBaseBackend):
     :param n_qubits: The maximum number of qubits supported by the backend.
     """
 
-    _persistent_handles = False
-    _supports_unitary = True
+    _persistent_handles: bool = False
+    _supports_unitary: bool = True
 
-    _memory = False
-    _noise_model = None
-    _needs_transpile = True
+    _memory: bool = False
+    _noise_model: Optional[NoiseModel] = None
+    _needs_transpile: bool = True
 
-    _qiskit_backend_name = "aer_simulator_unitary"
+    _qiskit_backend_name: str = "aer_simulator_unitary"
 
     def __init__(self, n_qubits: int = 40) -> None:
         super().__init__()
@@ -671,16 +671,16 @@ class AerDensityMatrixBackend(_AerBaseBackend):
     :param n_qubits: The maximum number of qubits supported by the backend.
     """
 
-    _supports_density_matrix = True
-    _supports_state = False
-    _memory = False
-    _noise_model = None
-    _needs_transpile = True
-    _supports_expectation = True
+    _supports_density_matrix: bool = True
+    _supports_state: bool = False
+    _memory: bool = False
+    _noise_model: Optional[NoiseModel] = None
+    _needs_transpile: bool = True
+    _supports_expectation: bool = True
 
-    _qiskit_backend_name = "aer_simulator_density_matrix"
+    _qiskit_backend_name: str = "aer_simulator_density_matrix"
 
-    _allowed_special_gates = {
+    _allowed_special_gates: set[OpType] = {
         OpType.Measure,
         OpType.Barrier,
         OpType.Reset,

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -660,6 +660,34 @@ class AerUnitaryBackend(_AerBaseBackend):
         ]
 
 
+class AerDensityMatrixBackend(_AerBaseBackend):
+    _supports_density_matrix = True
+    _memory = False
+    _noise_model = None
+    _needs_transpile = True
+    _supports_expectation = True
+
+    _qiskit_backend_name = "aer_simulator_density_matrix"
+
+    def __init__(self, n_qubits: int = 40) -> None:
+        super().__init__()
+        self._qiskit_backend = qiskit_aer_backend(self._qiskit_backend_name)
+        self._backend_info = BackendInfo(
+            name=type(self).__name__,
+            device_name=self._qiskit_backend_name,
+            version=__extension_version__,
+            architecture=FullyConnected(n_qubits),
+            gate_set=_tket_gate_set_from_qiskit_backend(self._qiskit_backend),
+            supports_midcircuit_measurement=True,  # is this correct?
+            misc={"characterisation": None},
+        )
+        self._required_predicates = [
+            NoClassicalControlPredicate(),
+            NoFastFeedforwardPredicate(),
+            GateSetPredicate(self._backend_info.gate_set),
+        ]
+
+
 def _process_noise_model(
     noise_model: NoiseModel, gate_set: Set[OpType]
 ) -> NoiseModelCharacterisation:

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -107,7 +107,7 @@ def qiskit_experimentresult_to_backendresult(
             for index in range(size):
                 q_bits.append(Qubit(name, index))
 
-    shots, counts, state, unitary = (None,) * 4
+    shots, counts, state, unitary, density_matrix = (None,) * 5
     datadict = result.data.to_dict()
     if _result_is_empty_shots(result):
         n_bits = len(c_bits) if c_bits else 0
@@ -133,6 +133,9 @@ def qiskit_experimentresult_to_backendresult(
         if "unitary" in datadict:
             unitary = datadict["unitary"].reverse_qargs().data
 
+        if "density_matrix" in datadict:
+            density_matrix = datadict["density_matrix"].reverse_qargs().data
+
     return BackendResult(
         c_bits=c_bits,
         q_bits=q_bits,
@@ -140,6 +143,7 @@ def qiskit_experimentresult_to_backendresult(
         counts=counts,
         state=state,
         unitary=unitary,
+        density_matrix=density_matrix,
         ppcirc=ppcirc,
     )
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1476,7 +1476,6 @@ def test_noisy_density_matrix_simulation() -> None:
     noise_model.add_quantum_error(depolarizing_error(0.6, 2), ["cz"], [1, 2])
 
     noisy_density_sim = AerDensityMatrixBackend(noise_model)
-    print(noisy_density_sim.backend_info)
 
     circ = Circuit(3)
     circ.X(0)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1465,9 +1465,10 @@ def test_noiseless_density_matrix_simulation() -> None:
     assert result1.get_density_matrix().shape == (8, 8)
     state_backend = AerStateBackend()
     statevector = state_backend.run_circuit(circ2).get_state()
-    assert np.allclose(
-        result2.get_density_matrix(), np.outer(statevector, statevector.conj())
-    )
+    noiseless_dm = result2.get_density_matrix()
+    assert np.allclose(noiseless_dm, np.outer(statevector, statevector.conj()))
+    # Check purity to verify that we have a pure state
+    assert np.trace(noiseless_dm**2).real == 1
 
 
 # https://github.com/CQCL/pytket-qiskit/issues/231
@@ -1491,4 +1492,11 @@ def test_noisy_density_matrix_simulation() -> None:
     assert noisy_density_sim.valid_circuit(circ)
 
     result = noisy_density_sim.run_circuit(circ)
-    assert result.get_density_matrix().shape == (8, 8)
+    noisy_dm = result.get_density_matrix()
+    assert noisy_dm.shape == (8, 8)
+    # Check purity to verify mixed state
+    assert np.trace(noisy_dm**2).real < 1
+
+
+test_noiseless_density_matrix_simulation()
+test_noisy_density_matrix_simulation()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1452,7 +1452,7 @@ def test_noiseless_density_matrix_simulation() -> None:
         result1.get_density_matrix(), np.outer(output_state, output_state.conj())
     )
     # Example with resets and conditional gates
-    # Deterministic if input is a computational basis state
+    # Prepares a state deterministically if input is a computational basis state
     circ2 = Circuit(3, 1)
     circ2.CCX(*range(3))
     circ2.U1(1 / 4, 2)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1496,7 +1496,3 @@ def test_noisy_density_matrix_simulation() -> None:
     assert noisy_dm.shape == (8, 8)
     # Check purity to verify mixed state
     assert np.trace(noisy_dm**2).real < 1
-
-
-test_noiseless_density_matrix_simulation()
-test_noisy_density_matrix_simulation()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1451,7 +1451,7 @@ def test_noiseless_density_matrix_simulation() -> None:
     assert noiseless_dm1.shape == (8, 8)
     assert np.allclose(noiseless_dm1, np.outer(output_state, output_state.conj()))
     # Check purity to verify that we have a pure state
-    assert np.trace(noiseless_dm1**2).real == 1
+    np.isclose(np.trace(noiseless_dm1**2).real, 1)
 
     # Example with resets and conditional gates
     # Prepares a state deterministically if input is a computational basis state
@@ -1470,7 +1470,7 @@ def test_noiseless_density_matrix_simulation() -> None:
     noiseless_dm2 = result2.get_density_matrix()
     assert np.allclose(noiseless_dm2, np.outer(statevector, statevector.conj()))
     # Check purity to verify that we have a pure state
-    assert np.trace(noiseless_dm2**2).real == 1
+    assert np.isclose(np.trace(noiseless_dm2**2).real, 1)
 
 
 # https://github.com/CQCL/pytket-qiskit/issues/231
@@ -1497,4 +1497,4 @@ def test_noisy_density_matrix_simulation() -> None:
     noisy_dm = result.get_density_matrix()
     assert noisy_dm.shape == (8, 8)
     # Check purity to verify mixed state
-    assert np.trace(noisy_dm**2).real < 1
+    assert np.trace(noisy_dm**2).real < 0.99

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1448,7 +1448,8 @@ def test_noiseless_density_matrix_simulation() -> None:
     assert np.allclose(
         result1.get_density_matrix(), np.outer(output_state, output_state.conj())
     )
-    # Example with resets and conditional gates. Deterministic if input is a basis state
+    # Example with resets and conditional gates
+    # Deterministic if input is a computational basis state
     circ2 = Circuit(3, 1)
     circ2.CCX(*range(3))
     circ2.U1(1 / 4, 2)
@@ -1469,11 +1470,13 @@ def test_noiseless_density_matrix_simulation() -> None:
 # https://github.com/CQCL/pytket-qiskit/issues/231
 def test_noisy_density_matrix_simulation() -> None:
 
+    # Test that __init__ works with a very simple noise model
     noise_model = NoiseModel()
     noise_model.add_quantum_error(depolarizing_error(0.6, 2), ["cz"], [0, 1])
     noise_model.add_quantum_error(depolarizing_error(0.6, 2), ["cz"], [1, 2])
 
     noisy_density_sim = AerDensityMatrixBackend(noise_model)
+    print(noisy_density_sim.backend_info)
 
     circ = Circuit(3)
     circ.X(0)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1348,7 +1348,7 @@ def test_statevector_simulator_gateset_deterministic() -> None:
     circ.H(2)
     circ.Measure(2, 0)
     circ.CZ(0, 1, condition_bits=[0], condition_value=1)
-    circ.add_gate(OpType.Reset, [2])
+    circ.Reset(2)
     compiled_circ = sv_backend.get_compiled_circuit(circ)
     assert sv_backend.valid_circuit(compiled_circ)
     tket_statevector = sv_backend.run_circuit(compiled_circ).get_state()
@@ -1459,7 +1459,7 @@ def test_noiseless_density_matrix_simulation() -> None:
     circ2.H(2)
     circ2.Measure(2, 0)
     circ2.CZ(0, 1, condition_bits=[0], condition_value=1)
-    circ2.add_gate(OpType.Reset, [2])
+    circ2.Reset(2)
 
     result2 = density_matrix_backend.run_circuit(circ2)
     assert result1.get_density_matrix().shape == (8, 8)
@@ -1492,6 +1492,3 @@ def test_noisy_density_matrix_simulation() -> None:
 
     result = noisy_density_sim.run_circuit(circ)
     assert result.get_density_matrix().shape == (8, 8)
-
-
-test_noisy_density_matrix_simulation()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -77,6 +77,7 @@ from pytket.utils.expectations import (
     get_pauli_expectation_value,
     get_operator_expectation_value,
 )
+from pytket.architecture import FullyConnected
 from pytket.utils.operators import QubitPauliOperator
 from pytket.utils.results import compare_statevectors, compare_unitaries
 
@@ -1436,7 +1437,9 @@ def test_ibmq_local_emulator(
 # https://github.com/CQCL/pytket-qiskit/issues/231
 def test_noiseless_density_matrix_simulation() -> None:
     density_matrix_backend = AerDensityMatrixBackend()
-    assert density_matrix_backend.supports_density_matrix == True
+    assert density_matrix_backend.supports_density_matrix is True
+
+    assert isinstance(density_matrix_backend.backend_info.architecture, FullyConnected)
 
     circ1 = Circuit(3).X(0).X(1).CCX(0, 1, 2)
 
@@ -1476,6 +1479,8 @@ def test_noisy_density_matrix_simulation() -> None:
     noise_model.add_quantum_error(depolarizing_error(0.6, 2), ["cz"], [1, 2])
 
     noisy_density_sim = AerDensityMatrixBackend(noise_model)
+    assert isinstance(noisy_density_sim.backend_info.architecture, Architecture)
+    assert len(noisy_density_sim.backend_info.architecture.nodes) == 3
 
     circ = Circuit(3)
     circ.X(0)
@@ -1487,3 +1492,6 @@ def test_noisy_density_matrix_simulation() -> None:
 
     result = noisy_density_sim.run_circuit(circ)
     assert result.get_density_matrix().shape == (8, 8)
+
+
+test_noisy_density_matrix_simulation()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1446,11 +1446,13 @@ def test_noiseless_density_matrix_simulation() -> None:
     output_state = np.array([0] * 7 + [1])
 
     result1 = density_matrix_backend.run_circuit(circ1)
+    noiseless_dm1 = result1.get_density_matrix()
 
-    assert result1.get_density_matrix().shape == (8, 8)
-    assert np.allclose(
-        result1.get_density_matrix(), np.outer(output_state, output_state.conj())
-    )
+    assert noiseless_dm1.shape == (8, 8)
+    assert np.allclose(noiseless_dm1, np.outer(output_state, output_state.conj()))
+    # Check purity to verify that we have a pure state
+    assert np.trace(noiseless_dm1**2).real == 1
+
     # Example with resets and conditional gates
     # Prepares a state deterministically if input is a computational basis state
     circ2 = Circuit(3, 1)
@@ -1465,10 +1467,10 @@ def test_noiseless_density_matrix_simulation() -> None:
     assert result1.get_density_matrix().shape == (8, 8)
     state_backend = AerStateBackend()
     statevector = state_backend.run_circuit(circ2).get_state()
-    noiseless_dm = result2.get_density_matrix()
-    assert np.allclose(noiseless_dm, np.outer(statevector, statevector.conj()))
+    noiseless_dm2 = result2.get_density_matrix()
+    assert np.allclose(noiseless_dm2, np.outer(statevector, statevector.conj()))
     # Check purity to verify that we have a pure state
-    assert np.trace(noiseless_dm**2).real == 1
+    assert np.trace(noiseless_dm2**2).real == 1
 
 
 # https://github.com/CQCL/pytket-qiskit/issues/231


### PR DESCRIPTION
# Description

Adding a new `AerDensityMatrixBackend` class. Unlike other density matrix simulators available through the pytket extensions this emulator should support an optional `NoiseModel` in the constructor.

There's a decent amount of duplication from the `AerBackend` implementation for `BackendInfo`. Maybe there's a smarter and less error prone way to do it. 

# Related issues
closes #231 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
