### PR TITLE
refactor: Simplify some internals of `qiskit_to_tk` conversion

### DIFF
--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -265,32 +265,33 @@ def _string_to_circuit(
 
     # We iterate through the string in reverse to add the
     # gates in the correct order (endian-ness).
-    for count, char in enumerate(reversed(circuit_string)):
-        if char == "0":
-            pass
-        elif char == "1":
-            circ.X(count)
-        elif char == "+":
-            circ.H(count)
-        elif char == "-":
-            circ.X(count)
-            circ.H(count)
-        elif char == "r":
-            circ.H(count)
-            circ.S(count)
-        elif char == "l":
-            circ.H(count)
-            circ.Sdg(count)
-        else:
-            raise ValueError(
-                f"Cannot parse string for character {char}. "
-                + "The supported characters are {'0', '1', '+', '-', 'r', 'l'}."
-            )
+    for qubit_index, character in enumerate(reversed(circuit_string)):
+        match character:
+            case "0":
+                pass
+            case "1":
+                circ.X(qubit_index)
+            case "+":
+                circ.H(qubit_index)
+            case "-":
+                circ.X(qubit_index)
+                circ.H(qubit_index)
+            case "r":
+                circ.H(qubit_index)
+                circ.S(qubit_index)
+            case "l":
+                circ.H(qubit_index)
+                circ.Sdg(qubit_index)
+            case _:
+                raise ValueError(
+                    f"Cannot parse string for character {character}. "
+                    + "The supported characters are {'0', '1', '+', '-', 'r', 'l'}."
+                )
 
     return circ
 
 
-def get_controlled_tket_optype(c_gate: ControlledGate) -> OpType:
+def _get_controlled_tket_optype(c_gate: ControlledGate) -> OpType:
     if c_gate.base_class in _known_qiskit_gate:
         # First we check if the gate is in _known_qiskit_gate
         # this avoids CZ being converted to CnZ
@@ -443,7 +444,7 @@ class CircuitBuilder:
             self.add_xs(num_ctrl_qubits, ctrl_state, qargs)
             optype = None
             if isinstance(instr, ControlledGate):
-                optype = get_controlled_tket_optype(instr)
+                optype = _get_controlled_tket_optype(instr)
             elif type(instr) in (PauliEvolutionGate, UnitaryGate):
                 pass  # Special handling below
             else:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -368,7 +368,8 @@ def _add_state_preparation(
             tkc.add_circuit(circuit, qubits)
         else:
             raise TypeError(
-                "Unrecognised type of Instruction.params when trying to convert Initialize or StatePreparation instruction."
+                "Unrecognised type of Instruction.params "
+                + "when trying to convert Initialize or StatePreparation instruction."
             )
 
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -463,8 +463,8 @@ class CircuitBuilder:
                 # Handling of PauliEvolutionGate and UnitaryGate below
                 optype = _optype_from_qiskit_instruction(instruction=instr)
 
-            qubits = [self.qbmap[qbit] for qbit in qargs]
-            bits = [self.cbmap[bit] for bit in cargs]
+            qubits: list[Qubit] = [self.qbmap[qbit] for qbit in qargs]
+            bits: list[Bit] = [self.cbmap[bit] for bit in cargs]
 
             if optype == OpType.QControlBox:
                 params = [param_to_tk(p) for p in instr.base_gate.params]
@@ -479,7 +479,9 @@ class CircuitBuilder:
                         sub_circ, instr.base_gate, sub_circ.qubits, condition_kwargs
                     )
                 else:
-                    base_tket_gate = _known_qiskit_gate[instr.base_gate.base_class]
+                    base_tket_gate: OpType = _known_qiskit_gate[
+                        instr.base_gate.base_class
+                    ]
                     sub_circ.add_gate(
                         base_tket_gate, params, list(range(n_base_qubits))
                     )
@@ -784,7 +786,7 @@ order or only one bit of one register"""
         ) from error
     params = _get_params(op, symb_map)
     g = gatetype(*params)
-    if type(phase) == float:
+    if type(phase) is float:
         qcirc.global_phase += phase * np.pi
     else:
         qcirc.global_phase += sympify(phase * sympy.pi)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -334,7 +334,7 @@ def _optype_from_qiskit_instruction(instruction: Instruction) -> OpType:
         )
 
 
-def _add_state_preparation_box(
+def _add_state_preparation(
     tkc: Circuit, qubits: List[Qubit], instr: Instruction
 ) -> None:
     """ """
@@ -491,7 +491,7 @@ class CircuitBuilder:
 
             elif isinstance(instr, (Initialize, StatePreparation)):
                 # Check how Initialize or StatePrep is constructed
-                _add_state_preparation_box(self.tkc, qubits, instr)
+                _add_state_preparation(self.tkc, qubits, instr)
 
             elif type(instr) is PauliEvolutionGate:
                 qpo = _qpo_from_peg(instr, qubits)
@@ -819,7 +819,7 @@ Param = Union[float, "sympy.Expr"]  # Type for TK1 and U3 parameters
 # Use the U3 gate for tk1_replacement as this is a member of _supported_tket_gates
 def _tk1_to_u3(a: Param, b: Param, c: Param) -> Circuit:
     tk1_circ = Circuit(1)
-    tk1_circ.add_gate(OpType.U3, [b, a - 1 / 2, c + 1 / 2], [0]).add_phase(-(a + c) / 2)
+    tk1_circ.U3(b, a - 1 / 2, c + 1 / 2, 0).add_phase(-(a + c) / 2)
     return tk1_circ
 
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -294,26 +294,26 @@ def _add_statepreparation_circuit(
     tkc: Circuit, qubits: List[Qubit], instr: Instruction
 ) -> None:
     # Check how Initialize or StatePrep is constructed
-
     if len(instr.params) != 1:
         if isinstance(instr.params[0], str):
             # Parse string to get the right single qubit gates
-            circuit_string = "".join(instr.params)
+            circuit_string: str = "".join(instr.params)
             circuit = _string_to_circuit(
                 circuit_string, instr.num_qubits, qiskit_instruction=instr
             )
             tkc.add_circuit(circuit, qubits)
         else:
-            amplitude_list = instr.params
+            amplitude_array = np.array(instr.params)
             if isinstance(instr, Initialize):
                 pytket_state_prep_box = StatePreparationBox(
-                    amplitude_list, with_initial_reset=True  # type: ignore
+                    amplitude_array, with_initial_reset=True
                 )
             else:
                 pytket_state_prep_box = StatePreparationBox(
-                    amplitude_list, with_initial_reset=False  # type: ignore
+                    amplitude_array, with_initial_reset=False
                 )
             # Need to reverse qubits here (endian-ness)
+            # TODO pass same list of qubits to add_circuit
             reversed_qubits = list(reversed(qubits))
             tkc.add_gate(pytket_state_prep_box, reversed_qubits)
     else:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -18,15 +18,11 @@
 from collections import defaultdict
 from typing import (
     Callable,
-    Dict,
-    List,
-    Optional,
     Union,
+    Optional,
     Any,
     Iterable,
     cast,
-    Set,
-    Tuple,
     TypeVar,
     TYPE_CHECKING,
 )
@@ -184,7 +180,7 @@ _known_gate_rev_phase[OpType.V] = (qiskit_gates.SXGate, -0.25)
 _known_gate_rev_phase[OpType.Vdg] = (qiskit_gates.SXdgGate, 0.25)
 
 # use minor signature hacks to figure out the string names of qiskit Gate objects
-_gate_str_2_optype: Dict[str, OpType] = dict()
+_gate_str_2_optype: dict[str, OpType] = dict()
 for gate, optype in _known_qiskit_gate.items():
     if gate in (
         UnitaryGate,
@@ -208,7 +204,7 @@ _gate_str_2_optype_rev = {v: k for k, v in _gate_str_2_optype.items()}
 _gate_str_2_optype_rev[OpType.Unitary1qBox] = "unitary"
 
 
-def _tk_gate_set(config: QasmBackendConfiguration) -> Set[OpType]:
+def _tk_gate_set(config: QasmBackendConfiguration) -> set[OpType]:
     """Set of tket gate types supported by the qiskit backend"""
     if config.simulator:
         gate_set = {
@@ -226,7 +222,7 @@ def _tk_gate_set(config: QasmBackendConfiguration) -> Set[OpType]:
         }
 
 
-def _qpo_from_peg(peg: PauliEvolutionGate, qubits: List[Qubit]) -> QubitPauliOperator:
+def _qpo_from_peg(peg: PauliEvolutionGate, qubits: list[Qubit]) -> QubitPauliOperator:
     op = peg.operator
     t = peg.params[0]
     qpodict = {}
@@ -335,7 +331,7 @@ def _optype_from_qiskit_instruction(instruction: Instruction) -> OpType:
 
 
 def _add_state_preparation(
-    tkc: Circuit, qubits: List[Qubit], instr: Instruction
+    tkc: Circuit, qubits: list[Qubit], instr: Instruction
 ) -> None:
     """ """
     # Check how Initialize or StatePrep is constructed
@@ -376,8 +372,8 @@ def _add_state_preparation(
 class CircuitBuilder:
     def __init__(
         self,
-        qregs: List[QuantumRegister],
-        cregs: Optional[List[ClassicalRegister]] = None,
+        qregs: list[QuantumRegister],
+        cregs: Optional[list[ClassicalRegister]] = None,
         name: Optional[str] = None,
         phase: Optional[sympy.Expr] = None,
     ):
@@ -408,8 +404,8 @@ class CircuitBuilder:
     def add_xs(
         self,
         num_ctrl_qubits: Optional[int],
-        ctrl_state: Optional[Union[str, int]],
-        qargs: List["Qubit"],
+        ctrl_state: Optional[str | int],
+        qargs: list["Qubit"],
     ) -> None:
         if ctrl_state is not None:
             assert isinstance(num_ctrl_qubits, int)
@@ -542,8 +538,8 @@ class CircuitBuilder:
 def add_qiskit_unitary_to_tkc(
     tkc: Circuit,
     u_gate: UnitaryGate,
-    qubits: List[Qubit],
-    condition_kwargs: Dict[str, Any],
+    qubits: list[Qubit],
+    condition_kwargs: dict[str, Any],
 ) -> None:
     # Note reversal of qubits, to account for endianness (pytket unitaries
     # are ILO-BE == DLO-LE; qiskit unitaries are ILO-LE == DLO-BE).
@@ -605,7 +601,7 @@ def qiskit_to_tk(qcirc: QuantumCircuit, preserve_param_uuid: bool = False) -> Ci
     return builder.circuit()
 
 
-def param_to_tk(p: Union[float, ParameterExpression]) -> sympy.Expr:
+def param_to_tk(p: float | ParameterExpression) -> sympy.Expr:
     if isinstance(p, ParameterExpression):
         symexpr = p._symbol_expr
         try:
@@ -617,8 +613,8 @@ def param_to_tk(p: Union[float, ParameterExpression]) -> sympy.Expr:
 
 
 def param_to_qiskit(
-    p: sympy.Expr, symb_map: Dict[Parameter, sympy.Symbol]
-) -> Union[float, ParameterExpression]:
+    p: sympy.Expr, symb_map: dict[Parameter, sympy.Symbol]
+) -> float | ParameterExpression:
     ppi = p * sympy.pi
     if len(ppi.free_symbols) == 0:
         return float(ppi.evalf())
@@ -627,19 +623,19 @@ def param_to_qiskit(
 
 
 def _get_params(
-    op: Op, symb_map: Dict[Parameter, sympy.Symbol]
-) -> List[Union[float, ParameterExpression]]:
+    op: Op, symb_map: dict[Parameter, sympy.Symbol]
+) -> list[float | ParameterExpression]:
     return [param_to_qiskit(p, symb_map) for p in op.params]
 
 
 def append_tk_command_to_qiskit(
     op: "Op",
-    args: List["UnitID"],
+    args: list["UnitID"],
     qcirc: QuantumCircuit,
-    qregmap: Dict[str, QuantumRegister],
-    cregmap: Dict[str, ClassicalRegister],
-    symb_map: Dict[Parameter, sympy.Symbol],
-    range_preds: Dict[Bit, Tuple[List["UnitID"], int]],
+    qregmap: dict[str, QuantumRegister],
+    cregmap: dict[str, ClassicalRegister],
+    symb_map: dict[Parameter, sympy.Symbol],
+    range_preds: dict[Bit, tuple[list["UnitID"], int]],
 ) -> InstructionSet:
     optype = op.type
     if optype == OpType.Measure:
@@ -849,7 +845,7 @@ def tk_to_qiskit(
     if replace_implicit_swaps:
         tkc.replace_implicit_wire_swaps()
     qcirc = QuantumCircuit(name=tkc.name)
-    qreg_sizes: Dict[str, int] = {}
+    qreg_sizes: dict[str, int] = {}
     for qb in tkc.qubits:
         if len(qb.index) != 1:
             raise NotImplementedError("Qiskit registers must use a single index")
@@ -870,7 +866,7 @@ def tk_to_qiskit(
             cregmap.update({c_reg.name: qis_reg})
             qcirc.add_register(qis_reg)
     symb_map = {Parameter(str(s)): s for s in tkc.free_symbols()}
-    range_preds: Dict[Bit, Tuple[List["UnitID"], int]] = dict()
+    range_preds: dict[Bit, tuple[list["UnitID"], int]] = dict()
 
     # Apply a rebase to the set of pytket gates which have replacements in qiskit
     supported_gate_rebase.apply(tkc)
@@ -901,7 +897,7 @@ def tk_to_qiskit(
     return qcirc
 
 
-def process_characterisation(backend: "BackendV1") -> Dict[str, Any]:
+def process_characterisation(backend: "BackendV1") -> dict[str, Any]:
     """Convert a :py:class:`qiskit.providers.backend.BackendV1` to a dictionary
      containing device Characteristics
 
@@ -917,7 +913,7 @@ def process_characterisation(backend: "BackendV1") -> Dict[str, Any]:
 
 def process_characterisation_from_config(
     config: QasmBackendConfiguration, properties: Optional[BackendProperties]
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Obtain a dictionary containing device Characteristics given config and props.
 
     :param config: A IBMQ configuration object
@@ -942,7 +938,7 @@ def process_characterisation_from_config(
     n_qubits = config.n_qubits
     if coupling_map is None:
         # Assume full connectivity
-        arc: Union[FullyConnected, Architecture] = FullyConnected(n_qubits)
+        arc: FullyConnected | Architecture = FullyConnected(n_qubits)
     else:
         arc = Architecture(coupling_map)
 
@@ -992,14 +988,14 @@ def process_characterisation_from_config(
     K1 = TypeVar("K1")
     K2 = TypeVar("K2")
     V = TypeVar("V")
-    convert_keys_t = Callable[[Callable[[K1], K2], Dict[K1, V]], Dict[K2, V]]
+    convert_keys_t = Callable[[Callable[[K1], K2], dict[K1, V]], dict[K2, V]]
     # convert qubits to architecture Nodes
     convert_keys: convert_keys_t = lambda f, d: {f(k): v for k, v in d.items()}
     node_errors = convert_keys(lambda q: Node(q), node_errors)
     link_errors = convert_keys(lambda p: (Node(p[0]), Node(p[1])), link_errors)
     readout_errors = convert_keys(lambda q: Node(q), readout_errors)
 
-    characterisation: Dict[str, Any] = dict()
+    characterisation: dict[str, Any] = dict()
     characterisation["NodeErrors"] = node_errors
     characterisation["EdgeErrors"] = link_errors
     characterisation["ReadoutErrors"] = readout_errors
@@ -1013,8 +1009,8 @@ def process_characterisation_from_config(
 
 
 def get_avg_characterisation(
-    characterisation: Dict[str, Any]
-) -> Dict[str, Dict[Node, float]]:
+    characterisation: dict[str, Any]
+) -> dict[str, dict[Node, float]]:
     """
     Convert gate-specific characterisation into readout, one- and two-qubit errors
 
@@ -1025,19 +1021,19 @@ def get_avg_characterisation(
     K = TypeVar("K")
     V1 = TypeVar("V1")
     V2 = TypeVar("V2")
-    map_values_t = Callable[[Callable[[V1], V2], Dict[K, V1]], Dict[K, V2]]
+    map_values_t = Callable[[Callable[[V1], V2], dict[K, V1]], dict[K, V2]]
     map_values: map_values_t = lambda f, d: {k: f(v) for k, v in d.items()}
 
-    node_errors = cast(Dict[Node, Dict[OpType, float]], characterisation["NodeErrors"])
+    node_errors = cast(dict[Node, dict[OpType, float]], characterisation["NodeErrors"])
     link_errors = cast(
-        Dict[Tuple[Node, Node], Dict[OpType, float]], characterisation["EdgeErrors"]
+        dict[tuple[Node, Node], dict[OpType, float]], characterisation["EdgeErrors"]
     )
     readout_errors = cast(
-        Dict[Node, List[List[float]]], characterisation["ReadoutErrors"]
+        dict[Node, list[list[float]]], characterisation["ReadoutErrors"]
     )
 
-    avg: Callable[[Dict[Any, float]], float] = lambda xs: sum(xs.values()) / len(xs)
-    avg_mat: Callable[[List[List[float]]], float] = (
+    avg: Callable[[dict[Any, float]], float] = lambda xs: sum(xs.values()) / len(xs)
+    avg_mat: Callable[[list[list[float]]], float] = (
         lambda xs: (xs[0][1] + xs[1][0]) / 2.0
     )
     avg_readout_errors = map_values(avg_mat, readout_errors)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -313,7 +313,8 @@ def _get_controlled_tket_optype(c_gate: ControlledGate) -> OpType:
                 return OpType.QControlBox
             else:
                 raise NotImplementedError(
-                    f"Conversion of qiskit ControlledGate with base gate {c_gate.base_gate}"
+                    "Conversion of qiskit ControlledGate with base gate "
+                    + f"base gate {c_gate.base_gate}"
                     + "not implemented."
                 )
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -302,15 +302,15 @@ def _add_statepreparation_circuit(
         )
         tkc.add_circuit(circuit, qubits)
 
-    elif len(instr.params) != 1:
-        amplitude_list = instr.params
+    if len(instr.params) != 1:
+        amplitude_list: list[complex] = instr.params
         if isinstance(instr, Initialize):
             pytket_state_prep_box = StatePreparationBox(
-                amplitude_list, with_initial_reset=True  # type: ignore
+                amplitude_list, with_initial_reset=True
             )
         else:
             pytket_state_prep_box = StatePreparationBox(
-                amplitude_list, with_initial_reset=False  # type: ignore
+                amplitude_list, with_initial_reset=False
             )
         # Need to reverse qubits here (endian-ness)
         reversed_qubits = list(reversed(qubits))

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -20,7 +20,6 @@ from typing import (
     Callable,
     Optional,
     Union,
-    Optional,
     Any,
     Iterable,
     cast,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -335,18 +335,6 @@ def _optype_from_qiskit_instruction(instruction: Instruction) -> OpType:
         )
 
 
-def _state_prep_box_from_amplitudes(
-    amplitudes: NDArray[np.complex128], prep: Initialize | StatePreparation
-) -> StatePreparationBox:
-    if isinstance(prep, Initialize):
-        pytket_state_prep_box = StatePreparationBox(amplitudes, with_initial_reset=True)
-    else:
-        pytket_state_prep_box = StatePreparationBox(
-            amplitudes, with_initial_reset=False
-        )
-    return pytket_state_prep_box
-
-
 def _add_state_preparation(
     tkc: Circuit, qubits: list[Qubit], prep: Initialize | StatePreparation
 ) -> None:
@@ -365,9 +353,10 @@ def _add_state_preparation(
             tkc.add_circuit(circuit, qubits)
         else:
             amplitude_array: NDArray[np.complex128] = np.array(prep.params)
-            pytket_state_prep_box = _state_prep_box_from_amplitudes(
-                amplitude_array, prep
+            pytket_state_prep_box = StatePreparationBox(
+                amplitude_array, with_initial_reset=(type(prep) is Initialize)
             )
+
             # Need to reverse qubits here (endian-ness)
             # TODO pass same list of qubits to add_circuit
             reversed_qubits = list(reversed(qubits))

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -411,13 +411,13 @@ class CircuitBuilder:
             instr, qargs, cargs = datum.operation, datum.qubits, datum.clbits
             condition_kwargs = {}
             if instr.condition is not None:
-                if type(instr.condition[0]) == ClassicalRegister:
+                if type(instr.condition[0]) is ClassicalRegister:
                     cond_reg = self.cregmap[instr.condition[0]]
                     condition_kwargs = {
                         "condition_bits": [cond_reg[k] for k in range(len(cond_reg))],
                         "condition_value": instr.condition[1],
                     }
-                elif type(instr.condition[0]) == Clbit:
+                elif type(instr.condition[0]) is Clbit:
                     # .find_bit() returns type:
                     #    tuple[index, list[tuple[ClassicalRegister, index]]]
                     # We assume each bit belongs to exactly one register.

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -296,23 +296,25 @@ def get_controlled_tket_optype(c_gate: ControlledGate) -> OpType:
         # this avoids CZ being converted to CnZ
         known_optype = _known_qiskit_gate[c_gate.base_class]
         return known_optype
-    elif c_gate.base_gate.base_class is qiskit_gates.RYGate:
-        return OpType.CnRy
-    elif c_gate.base_gate.base_class is qiskit_gates.YGate:
-        return OpType.CnY
-    elif c_gate.base_gate.base_class is qiskit_gates.ZGate:
-        return OpType.CnZ
-    else:
-        if (
-            c_gate.base_gate.base_class in _known_qiskit_gate
-            or c_gate.base_gate.base_class is UnitaryGate
-        ):
-            return OpType.QControlBox
-        else:
-            raise NotImplementedError(
-                f"Conversion of qiskit ControlledGate with base gate {c_gate.base_gate}"
-                + "not implemented."
-            )
+
+    match c_gate.base_gate.base_class:
+        case qiskit_gates.RYGate:
+            return OpType.CnRy
+        case qiskit_gates.YGate:
+            return OpType.CnY
+        case qiskit_gates.ZGate:
+            return OpType.CnZ
+        case _:
+            if (
+                c_gate.base_gate.base_class in _known_qiskit_gate
+                or c_gate.base_gate.base_class is UnitaryGate
+            ):
+                return OpType.QControlBox
+            else:
+                raise NotImplementedError(
+                    f"Conversion of qiskit ControlledGate with base gate {c_gate.base_gate}"
+                    + "not implemented."
+                )
 
 
 def _add_statepreparation_circuit(

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -261,7 +261,7 @@ def _string_to_circuit(
     # If Initialize, add resets
     if isinstance(qiskit_instruction, Initialize):
         for qubit in circ.qubits:
-            circ.add_gate(OpType.Reset, [qubit])
+            circ.Reset(qubit)
 
     # We iterate through the string in reverse to add the
     # gates in the correct order (endian-ness).

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -357,7 +357,6 @@ def _add_state_preparation(
             )
 
             # Need to reverse qubits here (endian-ness)
-            # TODO pass same list of qubits to add_circuit
             reversed_qubits = list(reversed(qubits))
             tkc.add_gate(pytket_state_prep_box, reversed_qubits)
     else:
@@ -367,7 +366,10 @@ def _add_state_preparation(
             bit_string = bin(integer_parameter)[2:]
             circuit = _string_to_circuit(bit_string, prep.num_qubits, qiskit_prep=prep)
             tkc.add_circuit(circuit, qubits)
-        # TODO raise error
+        else:
+            raise TypeError(
+                "Unrecognised type of Instruction.params when trying to convert Initialize or StatePreparation instruction."
+            )
 
 
 def _get_pytket_condition_kwargs(

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -574,15 +574,12 @@ def qiskit_to_tk(qcirc: QuantumCircuit, preserve_param_uuid: bool = False) -> Ci
     Converts a qiskit :py:class:`qiskit.QuantumCircuit` to a pytket :py:class:`Circuit`.
 
     :param qcirc: A circuit to be converted
-    :type qcirc: QuantumCircuit
     :param preserve_param_uuid: Whether to preserve symbolic Parameter uuids
         by appending them to the tket Circuit symbol names as "_UUID:<uuid>".
         This can be useful if you want to reassign Parameters after conversion
         to tket and back, as it is necessary for Parameter object equality
         to be preserved.
-    :type preserve_param_uuid: bool
     :return: The converted circuit
-    :rtype: Circuit
     """
     circ_name = qcirc.name
     # Parameter uses a hidden _uuid for equality check
@@ -834,12 +831,9 @@ def tk_to_qiskit(
     circuit will be returned using the tket gates which are supported in qiskit.
 
     :param tkcirc: A :py:class:`Circuit` to be converted
-    :type tkcirc: Circuit
     :param replace_implicit_swaps: Implement implicit permutation by adding SWAPs
         to the end of the circuit.
-    :type replace_implicit_swaps: bool
     :return: The converted circuit
-    :rtype: QuantumCircuit
     """
     tkc = tkcirc.copy()  # Make a local copy of tkcirc
     if replace_implicit_swaps:
@@ -902,9 +896,7 @@ def process_characterisation(backend: "BackendV1") -> dict[str, Any]:
      containing device Characteristics
 
     :param backend: A backend to be converted
-    :type backend: BackendV1
     :return: A dictionary containing device characteristics
-    :rtype: dict
     """
     config = backend.configuration()
     props = backend.properties()
@@ -917,11 +909,8 @@ def process_characterisation_from_config(
     """Obtain a dictionary containing device Characteristics given config and props.
 
     :param config: A IBMQ configuration object
-    :type config: QasmBackendConfiguration
     :param properties: An optional IBMQ properties object
-    :type properties: Optional[BackendProperties]
     :return: A dictionary containing device characteristics
-    :rtype: dict
     """
 
     # TODO explicitly check for and separate 1 and 2 qubit gates


### PR DESCRIPTION
# Description

This PR begins a refactor of the `qiskit_to_tk` and `tk_to_qiskit` converters. Here I've focussed on refactoring some of the large `CircuitBuilder.add_qiskit_data` method (used as part of `qiskit_to_tk` into separate internal functions. I've added some short docstrings so its hopefully clearer whats going on.

There's still a lot to improve in the conversion code but I think it makes sense to do this refactor in several stages to make small fixes like https://github.com/CQCL/pytket-qiskit/issues/366 a bit easier.

I've avoided imporvements which involve user facing changes for now. Will add these in a follow up.

# Related issues

#313 

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
