### PR TITLE
chore: use python 3.10+ types, cleanup docs

### DIFF
--- a/.github/workflows/docs/conf.py
+++ b/.github/workflows/docs/conf.py
@@ -113,7 +113,7 @@ def correct_signature(
     what: str,
     name: str,
     obj: Any,
-    options: 
+    options: dict,
     signature: str,
     return_annotation: str,
 ) -> (str, str):

--- a/.github/workflows/docs/conf.py
+++ b/.github/workflows/docs/conf.py
@@ -48,7 +48,7 @@ autodoc_member_order = "groupwise"
 # The following code is for resolving broken hyperlinks in the doc.
 
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 from urllib.parse import urljoin
 
 from docutils import nodes

--- a/.github/workflows/docs/conf.py
+++ b/.github/workflows/docs/conf.py
@@ -113,7 +113,7 @@ def correct_signature(
     what: str,
     name: str,
     obj: Any,
-    options: Dict,
+    options: 
     signature: str,
     return_annotation: str,
 ) -> (str, str):

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -95,7 +95,7 @@ to disk:
 
     QiskitRuntimeService.save_account(channel="ibm_quantum", token=ibm_token, instance=inst)
 
-To see which devices you can access you can use the :py:meth:`~pytket.extensions.qiskit.IBMQBackend.available_devices` method on the :py:class:`IBMQBackend`. Note that it is possible to pass an optional ``instance`` argument to this method. This allows you to see which IBM devices are accessible with your credentials.
+To see which devices you can access, use the :py:meth:`IBMQBackend.available_devices` method. Note that it is possible to pass an optional ``instance`` argument to this method. This allows you to see which IBM devices are accessible with your credentials.
 
 ::
 
@@ -106,7 +106,7 @@ To see which devices you can access you can use the :py:meth:`~pytket.extensions
     backendinfo_list = backend.available_devices(instance=my_instance) 
     print([backend.device_name for backend in backendinfo_list])
 
-For more information see the documentation for `qiskit-ibm-runtime <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime>`_.
+For more information, see the documentation for `qiskit-ibm-runtime <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime>`_.
 
 
 Method 2: Saving credentials in a local pytket config file

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -75,12 +75,13 @@ In this section we are assuming that you have set the following variables with t
 ::
 
     # Replace the placeholders with your actual values
+
     ibm_token = '<your_ibm_token_here>'    
     hub = '<your_hub_here>'
     group = '<your_group_here>'
     project = '<your_project_here>'
 
-    my_instance=f"{hub}/{group}/{project}"
+    inst = f"{hub}/{group}/{project}"
 
 Method 1: Using :py:class:`QiskitRuntimeService`
 ------------------------------------------------
@@ -92,9 +93,9 @@ to disk:
 
     from qiskit_ibm_runtime import QiskitRuntimeService
 
-    QiskitRuntimeService.save_account(channel="ibm_quantum", token=ibm_token, instance=my_instance)
+    QiskitRuntimeService.save_account(channel="ibm_quantum", token=ibm_token, instance=inst)
 
-To see which devices you can access you can use the ``available_devices`` method on the :py:class:`IBMQBackend`. Note that it is possible to pass an optional ``instance`` argument to this method. This allows you to see which IBM devices are accessible with your credentials.
+To see which devices you can access you can use the :py:meth:`~pytket.extensions.qiskit.IBMQBackend.available_devices` method on the :py:class:`IBMQBackend`. Note that it is possible to pass an optional ``instance`` argument to this method. This allows you to see which IBM devices are accessible with your credentials.
 
 ::
 
@@ -105,12 +106,12 @@ To see which devices you can access you can use the ``available_devices`` method
     backendinfo_list = backend.available_devices(instance=my_instance) 
     print([backend.device_name for backend in backendinfo_list])
 
-For more information see the documentation for `qiskit-ibm-runtime <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime>`.
+For more information see the documentation for `qiskit-ibm-runtime <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime>`_.
 
 
 Method 2: Saving credentials in a local pytket config file
 ----------------------------------------------------------
-Alternatively, you can store your credentials in local pytket config using the :py:meth:`set_ibmq_config` method.
+Alternatively, you can store your credentials in local pytket config using the :py:meth:`~pytket.extensions.qiskit.backends.config.set_ibmq_config` method.
 
 ::
 
@@ -120,7 +121,7 @@ Alternatively, you can store your credentials in local pytket config using the :
 
 After saving your credentials you can access ``pytket-qiskit`` backend repeatedly without having to re-initialise your credentials.
 
-If you are a member of an IBM hub then you can add this information to ``set_ibmq_config`` as well.
+If you are a member of an IBM hub then you can add this information to :py:meth:`~pytket.extensions.qiskit.backends.config.set_ibmq_config` as well.
 
 ::
 
@@ -155,7 +156,7 @@ For instance those familiar with qiskit may wish to convert their circuits to py
 Default Compilation
 ===================
 
-Every :py:class:`Backend` in pytket has its own ``default_compilation_pass`` method. This method applies a sequence of optimisations to a circuit depending on the value of an ``optimisation_level`` parameter. This default compilation will ensure that the circuit meets all the constraints required to run on the :py:class:`Backend`. The passes applied by different levels of optimisation are specified in the table below.
+Every :py:class:`~pytket.backends.backend.Backend` in pytket has its own :py:meth:`~pytket.backends.Backend.default_compilation_pass` method. This method applies a sequence of optimisations to a circuit depending on the value of an ``optimisation_level`` parameter. This default compilation will ensure that the circuit meets all the constraints required to run on the :py:class:`~pytket.backends.backend.Backend`. The passes applied by different levels of optimisation are specified in the table below.
 
 .. list-table:: **Default compilation pass for the IBMQBackend and IBMQEmulatorBackend**
    :widths: 25 25 25
@@ -164,7 +165,7 @@ Every :py:class:`Backend` in pytket has its own ``default_compilation_pass`` met
    * - optimisation_level = 0
      - optimisation_level = 1
      - optimisation_level = 2 [1]
-   * - `DecomposeBoxes <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeBoxes>`_
+   * - :py:class:`DecomposeBoxes`
      - `DecomposeBoxes <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeBoxes>`_
      - `DecomposeBoxes <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeBoxes>`_
    * - self.rebase_pass [2]
@@ -194,10 +195,10 @@ Every :py:class:`Backend` in pytket has its own ``default_compilation_pass`` met
 
 * [1] If no value is specified then ``optimisation_level`` defaults to a value of 2.
 * [2] self.rebase_pass is a rebase to the gateset supported by the backend. For IBM quantum devices and emulators that is either {X, SX, Rz, CX} or {X, SX, Rz, ECR}. The more idealised Aer simulators have a much broader range of supported gates.
-* [3] Here :py:class:`CXMappingPass` maps program qubits to the architecture using a `NoiseAwarePlacement <https://tket.quantinuum.com/api-docs/placement.html#pytket.placement.NoiseAwarePlacement>`_
+* [3] Here :py:class:`~pytket._tket.passes.CXMappingPass` maps program qubits to the architecture using a :py:class:`~pytket._tket.placement.NoiseAwarePlacement`
 
 
-**Note:** The ``default_compilation_pass`` for :py:class:`AerBackend` is the same as above.
+**Note:** The :py:meth:`~AerBackend.default_compilation_pass` for :py:class:`AerBackend` is the same as above.
 
 
 Noise Modelling
@@ -214,7 +215,7 @@ Noise Modelling
 Using TKET directly on qiskit circuits
 ======================================
 
-For usage of :py:class:`TketBackend` see the `qiskit integration notebook example <https://tket.quantinuum.com/examples/qiskit_integration.html>`_.
+For usage of :py:class:`~pytket.extensions.qiskit.TketBackend` see the `qiskit integration notebook example <https://tket.quantinuum.com/examples/qiskit_integration.html>`_.
 
 .. currentmodule:: pytket.extensions.qiskit.tket_backend
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -165,7 +165,7 @@ Every :py:class:`~pytket.backends.backend.Backend` in pytket has its own :py:met
    * - optimisation_level = 0
      - optimisation_level = 1
      - optimisation_level = 2 [1]
-   * - :py:class:`DecomposeBoxes`
+   * - `DecomposeBoxes <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeBoxes>`_
      - `DecomposeBoxes <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeBoxes>`_
      - `DecomposeBoxes <https://tket.quantinuum.com/api-docs/passes.html#pytket.passes.DecomposeBoxes>`_
    * - self.rebase_pass [2]

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 import json
 from logging import warning
-from typing import Optional, Sequence, Union, cast, TYPE_CHECKING
+from typing import Optional, Sequence, cast, TYPE_CHECKING
 import warnings
 
 import numpy as np
@@ -246,7 +246,7 @@ class _AerBaseBackend(Backend):
     def process_circuits(
         self,
         circuits: Sequence[Circuit],
-        n_shots: Union[None, int, Sequence[Optional[int]]] = None,
+        n_shots: None | int | Sequence[Optional[int]] = None,
         valid_check: bool = True,
         **kwargs: KwargTypes,
     ) -> list[ResultHandle]:
@@ -351,7 +351,7 @@ class _AerBaseBackend(Backend):
     def _snapshot_expectation_value(
         self,
         circuit: Circuit,
-        hamiltonian: Union[SparsePauliOp, qk_Pauli],
+        hamiltonian: SparsePauliOp | qk_Pauli,
         valid_check: bool = True,
     ) -> complex:
         if valid_check:

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -442,7 +442,7 @@ class NoiseModelCharacterisation:
     architecture: Architecture
     node_errors: Optional[dict[Node, dict[OpType, float]]] = None
     edge_errors: Optional[dict[tuple[Node, Node], dict[OpType, float]]] = None
-    readout_errors: Optional[dict[Node, float]] = None
+    readout_errors: Optional[dict[Node, list[list[float]]]] = None
     averaged_node_errors: Optional[dict[Node, float]] = None
     averaged_edge_errors: Optional[dict[tuple[Node, Node], float]] = None
     averaged_readout_errors: Optional[dict[Node, float]] = None

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -17,15 +17,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 import json
 from logging import warning
-from typing import (
-    Dict,
-    Optional,
-    Sequence,
-    Union,
-    cast,
-    TYPE_CHECKING,
-    Set,
-)
+from typing import Optional, Sequence, Union, cast, TYPE_CHECKING
 import warnings
 
 import numpy as np
@@ -167,7 +159,7 @@ class _AerBaseBackend(Backend):
         self,
         arch: Architecture,
         optimisation_level: int = 2,
-        placement_options: Optional[Dict] = None,
+        placement_options: Optional[dict] = None,
     ) -> BasePass:
         assert optimisation_level in range(3)
         if placement_options is not None:
@@ -234,7 +226,7 @@ class _AerBaseBackend(Backend):
         return SequencePass([DecomposeBoxes(), FullPeepholeOptimise()])
 
     def default_compilation_pass(
-        self, optimisation_level: int = 2, placement_options: Optional[Dict] = None
+        self, optimisation_level: int = 2, placement_options: Optional[dict] = None
     ) -> BasePass:
         """
         See documentation for :py:meth:`IBMQBackend.default_compilation_pass`.
@@ -446,13 +438,13 @@ class NoiseModelCharacterisation:
     """Class to hold information from the processing of the noise model"""
 
     architecture: Architecture
-    node_errors: Optional[Dict] = None
-    edge_errors: Optional[Dict] = None
-    readout_errors: Optional[Dict] = None
+    node_errors: Optional[dict] = None
+    edge_errors: Optional[dict] = None
+    readout_errors: Optional[dict] = None
     averaged_node_errors: Optional[dict[Node, float]] = None
     averaged_edge_errors: Optional[dict[tuple[Node, Node], float]] = None
     averaged_readout_errors: Optional[dict[Node, float]] = None
-    generic_q_errors: Optional[Dict] = None
+    generic_q_errors: Optional[dict] = None
 
 
 def _map_trivial_noise_model_to_none(

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 import json
 from logging import warning
-from typing import Optional, Sequence, cast, TYPE_CHECKING
+from typing import Optional, Sequence, Any, cast, TYPE_CHECKING
 import warnings
 
 import numpy as np
@@ -438,13 +438,13 @@ class NoiseModelCharacterisation:
     """Class to hold information from the processing of the noise model"""
 
     architecture: Architecture
-    node_errors: Optional[dict] = None
-    edge_errors: Optional[dict] = None
-    readout_errors: Optional[dict] = None
+    node_errors: Optional[dict[Node, dict[OpType, float]]] = None
+    edge_errors: Optional[dict[tuple[Node, Node], dict[OpType, float]]] = None
+    readout_errors: Optional[dict[Node, float]] = None
     averaged_node_errors: Optional[dict[Node, float]] = None
     averaged_edge_errors: Optional[dict[tuple[Node, Node], float]] = None
     averaged_readout_errors: Optional[dict[Node, float]] = None
-    generic_q_errors: Optional[dict] = None
+    generic_q_errors: Optional[dict[str, Any]] = None
 
 
 def _map_trivial_noise_model_to_none(

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -19,7 +19,6 @@ import json
 from logging import warning
 from typing import (
     Dict,
-    List,
     Optional,
     Sequence,
     Union,

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -22,7 +22,6 @@ from typing import (
     List,
     Optional,
     Sequence,
-    Tuple,
     Union,
     cast,
     TYPE_CHECKING,
@@ -460,7 +459,7 @@ class NoiseModelCharacterisation:
     edge_errors: Optional[Dict] = None
     readout_errors: Optional[Dict] = None
     averaged_node_errors: Optional[Dict[Node, float]] = None
-    averaged_edge_errors: Optional[Dict[Tuple[Node, Node], float]] = None
+    averaged_edge_errors: Optional[Dict[tuple[Node, Node], float]] = None
     averaged_readout_errors: Optional[Dict[Node, float]] = None
     generic_q_errors: Optional[Dict] = None
 
@@ -674,7 +673,7 @@ def _process_noise_model(
     ]
 
     node_errors: dict[Node, dict[OpType, float]] = defaultdict(dict)
-    link_errors: dict[Tuple[Node, Node], dict[OpType, float]] = defaultdict(dict)
+    link_errors: dict[tuple[Node, Node], dict[OpType, float]] = defaultdict(dict)
     readout_errors: dict[Node, list[list[float]]] = {}
 
     generic_single_qerrors_dict: dict = defaultdict(list)
@@ -774,7 +773,7 @@ def _process_noise_model(
 
 def _sparse_to_zx_tup(
     pauli: QubitPauliString, n_qubits: int
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray]:
     x = np.zeros(n_qubits, dtype=np.bool_)
     z = np.zeros(n_qubits, dtype=np.bool_)
     for q, p in pauli.map.items():

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -94,7 +94,7 @@ def _default_q_index(q: Qubit) -> int:
 
 def _tket_gate_set_from_qiskit_backend(
     qiskit_aer_backend: "QiskitAerBackend",
-) -> Set[OpType]:
+) -> set[OpType]:
     config = qiskit_aer_backend.configuration()
     gate_set = {
         _gate_str_2_optype[gate_str]
@@ -473,7 +473,7 @@ def _map_trivial_noise_model_to_none(
 
 
 def _get_characterisation_of_noise_model(
-    noise_model: Optional[NoiseModel], gate_set: Set[OpType]
+    noise_model: Optional[NoiseModel], gate_set: set[OpType]
 ) -> NoiseModelCharacterisation:
     if noise_model is None:
         return NoiseModelCharacterisation(architecture=Architecture([]))
@@ -660,7 +660,7 @@ class AerUnitaryBackend(_AerBaseBackend):
 
 
 def _process_noise_model(
-    noise_model: NoiseModel, gate_set: Set[OpType]
+    noise_model: NoiseModel, gate_set: set[OpType]
 ) -> NoiseModelCharacterisation:
     # obtain approximations for gate errors from noise model by using probability of
     #  "identity" error

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -393,14 +393,10 @@ class _AerBaseBackend(Backend):
 
         :param state_circuit: Circuit that generates the desired state
             :math:`\\left|\\psi\\right>`.
-        :type state_circuit: Circuit
         :param pauli: Pauli operator
-        :type pauli: QubitPauliString
         :param valid_check: Explicitly check that the circuit satisfies all required
             predicates to run on the backend. Defaults to True
-        :type valid_check: bool, optional
         :return: :math:`\\left<\\psi | P | \\psi \\right>`
-        :rtype: complex
         """
         if self._noise_model:
             raise RuntimeError(
@@ -427,14 +423,10 @@ class _AerBaseBackend(Backend):
 
         :param state_circuit: Circuit that generates the desired state
             :math:`\\left|\\psi\\right>`.
-        :type state_circuit: Circuit
         :param operator: Operator :math:`H`.
-        :type operator: QubitPauliOperator
         :param valid_check: Explicitly check that the circuit satisfies all required
             predicates to run on the backend. Defaults to True
-        :type valid_check: bool, optional
         :return: :math:`\\left<\\psi | H | \\psi \\right>`
-        :rtype: complex
         """
         if self._noise_model:
             raise RuntimeError(
@@ -485,14 +477,11 @@ class AerBackend(_AerBaseBackend):
     Backend for running simulations on the Qiskit Aer QASM simulator.
 
     :param noise_model: Noise model to apply during simulation. Defaults to None.
-    :type noise_model: Optional[NoiseModel], optional
     :param simulation_method: Simulation method, see
         https://qiskit.github.io/qiskit-aer/stubs/qiskit_aer.AerSimulator.html
         for available values. Defaults to "automatic".
-    :type simulation_method: str
     :param crosstalk_params: Apply crosstalk noise simulation to the circuits before
         execution. `noise_model` will be overwritten if this is given. Default to None.
-    :type: Optional[`CrosstalkParams`]
     :param n_qubits: The maximum number of qubits supported by the backend.
     """
 

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -159,7 +159,7 @@ class _AerBaseBackend(Backend):
         self,
         arch: Architecture,
         optimisation_level: int = 2,
-        placement_options: Optional[dict] = None,
+        placement_options: Optional[dict[str, Any]] = None,
     ) -> BasePass:
         assert optimisation_level in range(3)
         if placement_options is not None:
@@ -226,7 +226,9 @@ class _AerBaseBackend(Backend):
         return SequencePass([DecomposeBoxes(), FullPeepholeOptimise()])
 
     def default_compilation_pass(
-        self, optimisation_level: int = 2, placement_options: Optional[dict] = None
+        self,
+        optimisation_level: int = 2,
+        placement_options: Optional[dict[str, Any]] = None,
     ) -> BasePass:
         """
         See documentation for :py:meth:`IBMQBackend.default_compilation_pass`.

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -142,13 +142,13 @@ class _AerBaseBackend(Backend):
     _qiskit_backend: "QiskitAerBackend"
     _backend_info: BackendInfo
     _memory: bool
-    _required_predicates: List[Predicate]
+    _required_predicates: list[Predicate]
     _noise_model: Optional[NoiseModel] = None
     _has_arch: bool = False
     _needs_transpile: bool = False
 
     @property
-    def required_predicates(self) -> List[Predicate]:
+    def required_predicates(self) -> list[Predicate]:
         return self._required_predicates
 
     @property
@@ -258,7 +258,7 @@ class _AerBaseBackend(Backend):
         n_shots: Union[None, int, Sequence[Optional[int]]] = None,
         valid_check: bool = True,
         **kwargs: KwargTypes,
-    ) -> List[ResultHandle]:
+    ) -> list[ResultHandle]:
         """
         See :py:meth:`pytket.backends.Backend.process_circuits`.
         Supported kwargs: `seed`, `postprocess`.
@@ -283,7 +283,7 @@ class _AerBaseBackend(Backend):
                 noisy_circuits.append(noisy_circ_builder.get_circuit())
             circuits = noisy_circuits
 
-        handle_list: List[Optional[ResultHandle]] = [None] * len(circuits)
+        handle_list: list[Optional[ResultHandle]] = [None] * len(circuits)
         seed = kwargs.get("seed")
         circuit_batches, batch_order = _batch_circuits(circuits, n_shots_list)
 
@@ -324,7 +324,7 @@ class _AerBaseBackend(Backend):
                 handle = ResultHandle(jobid, i, tkc_qubits_count[i], ppcirc_strs[i])
                 handle_list[ind] = handle
                 self._cache[handle] = {"job": job}
-        return cast(List[ResultHandle], handle_list)
+        return cast(list[ResultHandle], handle_list)
 
     def cancel(self, handle: ResultHandle) -> None:
         job: "AerJob" = self._cache[handle]["job"]
@@ -458,9 +458,9 @@ class NoiseModelCharacterisation:
     node_errors: Optional[Dict] = None
     edge_errors: Optional[Dict] = None
     readout_errors: Optional[Dict] = None
-    averaged_node_errors: Optional[Dict[Node, float]] = None
-    averaged_edge_errors: Optional[Dict[tuple[Node, Node], float]] = None
-    averaged_readout_errors: Optional[Dict[Node, float]] = None
+    averaged_node_errors: Optional[dict[Node, float]] = None
+    averaged_edge_errors: Optional[dict[tuple[Node, Node], float]] = None
+    averaged_readout_errors: Optional[dict[Node, float]] = None
     generic_q_errors: Optional[Dict] = None
 
 
@@ -711,7 +711,7 @@ def _process_noise_model(
                 )
             elif error["type"] == "roerror":
                 readout_errors[Node(q)] = cast(
-                    List[List[float]], error["probabilities"]
+                    list[list[float]], error["probabilities"]
                 )
             else:
                 raise RuntimeWarning("Error type not 'qerror' or 'roerror'.")

--- a/pytket/extensions/qiskit/backends/config.py
+++ b/pytket/extensions/qiskit/backends/config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, ClassVar, Dict, Optional, Type
+from typing import Any, ClassVar, Optional, Type
 from dataclasses import dataclass
 from pytket.config import PytketExtConfig
 
@@ -28,7 +28,7 @@ class QiskitConfig(PytketExtConfig):
 
     @classmethod
     def from_extension_dict(
-        cls: Type["QiskitConfig"], ext_dict: Dict[str, Any]
+        cls: Type["QiskitConfig"], ext_dict: dict[str, Any]
     ) -> "QiskitConfig":
         return cls(
             ext_dict.get("instance", None),

--- a/pytket/extensions/qiskit/backends/crosstalk_model.py
+++ b/pytket/extensions/qiskit/backends/crosstalk_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import List, Union, Optional
+from typing import Union, Optional
 from dataclasses import dataclass
 
 from qiskit_aer.noise import NoiseModel  # type: ignore

--- a/pytket/extensions/qiskit/backends/crosstalk_model.py
+++ b/pytket/extensions/qiskit/backends/crosstalk_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import List, Tuple, Union, Dict, Optional
+from typing import List, Union, Dict, Optional
 from dataclasses import dataclass
 
 from qiskit_aer.noise import NoiseModel  # type: ignore
@@ -93,13 +93,13 @@ class CrosstalkParams:
         on each qubit
     """
 
-    zz_crosstalks: Dict[Tuple[Qubit, Qubit], float]
+    zz_crosstalks: Dict[tuple[Qubit, Qubit], float]
     single_q_phase_errors: Dict[Qubit, float]
-    two_q_induced_phase_errors: Dict[Tuple[Qubit, Qubit], Tuple[Qubit, float]]
-    non_markovian_noise: List[Tuple[Qubit, float, float]]
+    two_q_induced_phase_errors: Dict[tuple[Qubit, Qubit], tuple[Qubit, float]]
+    non_markovian_noise: List[tuple[Qubit, float, float]]
     virtual_z: bool
     N: float
-    gate_times: Dict[Tuple[OpType, Tuple[Qubit, ...]], float]
+    gate_times: Dict[tuple[OpType, tuple[Qubit, ...]], float]
     phase_damping_error: Dict[Qubit, float]
     amplitude_damping_error: Dict[Qubit, float]
 
@@ -373,7 +373,7 @@ class NoisyCircuitBuilder:
 
 def get_gate_times_from_backendinfo(
     backend_info: BackendInfo,
-) -> Dict[Tuple[OpType, Tuple[Qubit, ...]], float]:
+) -> Dict[tuple[OpType, tuple[Qubit, ...]], float]:
     """Convert the gate time information stored in a `BackendInfo`
     into the format required by `NoisyCircuitBuilder`"""
     if (
@@ -381,7 +381,7 @@ def get_gate_times_from_backendinfo(
         or "GateTimes" not in backend_info.misc["characterisation"]
     ):
         raise ValueError("'GateTimes' is not present in the provided 'BackendInfo'")
-    gate_times: Dict[Tuple[OpType, Tuple[Qubit, ...]], float] = {}
+    gate_times: Dict[tuple[OpType, tuple[Qubit, ...]], float] = {}
     for gt in backend_info.misc["characterisation"]["GateTimes"]:
         # GateTimes are nanoseconds
         gate_times[_gate_str_2_optype[gt[0]], tuple([Node(q) for q in gt[1]])] = (

--- a/pytket/extensions/qiskit/backends/crosstalk_model.py
+++ b/pytket/extensions/qiskit/backends/crosstalk_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import List, Union, Dict, Optional
+from typing import List, Union, Optional
 from dataclasses import dataclass
 
 from qiskit_aer.noise import NoiseModel  # type: ignore
@@ -65,7 +65,7 @@ class NoiseGate:
 
 
 Instruction = Union[FractionalUnitary, Command, NoiseGate]
-Slice = List[Instruction]
+Slice = list[Instruction]
 EPS = 1e-9
 
 
@@ -93,15 +93,15 @@ class CrosstalkParams:
         on each qubit
     """
 
-    zz_crosstalks: Dict[tuple[Qubit, Qubit], float]
-    single_q_phase_errors: Dict[Qubit, float]
-    two_q_induced_phase_errors: Dict[tuple[Qubit, Qubit], tuple[Qubit, float]]
-    non_markovian_noise: List[tuple[Qubit, float, float]]
+    zz_crosstalks: dict[tuple[Qubit, Qubit], float]
+    single_q_phase_errors: dict[Qubit, float]
+    two_q_induced_phase_errors: dict[tuple[Qubit, Qubit], tuple[Qubit, float]]
+    non_markovian_noise: list[tuple[Qubit, float, float]]
     virtual_z: bool
     N: float
-    gate_times: Dict[tuple[OpType, tuple[Qubit, ...]], float]
-    phase_damping_error: Dict[Qubit, float]
-    amplitude_damping_error: Dict[Qubit, float]
+    gate_times: dict[tuple[OpType, tuple[Qubit, ...]], float]
+    phase_damping_error: dict[Qubit, float]
+    amplitude_damping_error: dict[Qubit, float]
 
     def get_noise_model(self) -> NoiseModel:
         """Construct a NoiseModel from phase_damping_error
@@ -158,10 +158,10 @@ class NoisyCircuitBuilder:
 
     def reset(self) -> None:
         """Clear the build cache"""
-        self._slices: List[Slice] = []
+        self._slices: list[Slice] = []
 
     @staticmethod
-    def _get_qubits(inst: Instruction) -> List[Qubit]:
+    def _get_qubits(inst: Instruction) -> list[Qubit]:
         if isinstance(inst, Command):
             return inst.qubits
         else:
@@ -170,7 +170,7 @@ class NoisyCircuitBuilder:
     def _append(
         self,
         inst: Instruction,
-        frontier: Dict[Qubit, int],
+        frontier: dict[Qubit, int],
     ) -> None:
         """Append a command to the splices in Tetris style"""
         args = self._get_qubits(inst)
@@ -187,7 +187,7 @@ class NoisyCircuitBuilder:
         for q in args:
             frontier[q] = slice_idx + 1
 
-    def _fill_gaps(self, frontier: Dict[Qubit, int]) -> None:
+    def _fill_gaps(self, frontier: dict[Qubit, int]) -> None:
         """Fill the gaps in the slices with identity `Unitary1qBox`es"""
         for idx, s in enumerate(self._slices):
             slice_qubits = set().union(*[self._get_qubits(inst) for inst in s])
@@ -366,14 +366,14 @@ class NoisyCircuitBuilder:
                     d.add_gate(inst.cmd.op, inst.cmd.args)
         return d
 
-    def get_slices(self) -> List[Slice]:
+    def get_slices(self) -> list[Slice]:
         """Return the internally stored slices"""
         return self._slices
 
 
 def get_gate_times_from_backendinfo(
     backend_info: BackendInfo,
-) -> Dict[tuple[OpType, tuple[Qubit, ...]], float]:
+) -> dict[tuple[OpType, tuple[Qubit, ...]], float]:
     """Convert the gate time information stored in a `BackendInfo`
     into the format required by `NoisyCircuitBuilder`"""
     if (
@@ -381,7 +381,7 @@ def get_gate_times_from_backendinfo(
         or "GateTimes" not in backend_info.misc["characterisation"]
     ):
         raise ValueError("'GateTimes' is not present in the provided 'BackendInfo'")
-    gate_times: Dict[tuple[OpType, tuple[Qubit, ...]], float] = {}
+    gate_times: dict[tuple[OpType, tuple[Qubit, ...]], float] = {}
     for gt in backend_info.misc["characterisation"]["GateTimes"]:
         # GateTimes are nanoseconds
         gate_times[_gate_str_2_optype[gt[0]], tuple([Node(q) for q in gt[1]])] = (

--- a/pytket/extensions/qiskit/backends/crosstalk_model.py
+++ b/pytket/extensions/qiskit/backends/crosstalk_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Union, Optional
+from typing import Optional
 from dataclasses import dataclass
 
 from qiskit_aer.noise import NoiseModel  # type: ignore
@@ -64,7 +64,7 @@ class NoiseGate:
     type: str
 
 
-Instruction = Union[FractionalUnitary, Command, NoiseGate]
+Instruction = FractionalUnitary | Command | NoiseGate
 Slice = list[Instruction]
 EPS = 1e-9
 
@@ -205,7 +205,7 @@ class NoisyCircuitBuilder:
         self._fill_gaps(frontier)
 
     @staticmethod
-    def _get_ubox(u: np.ndarray) -> Union[Unitary1qBox, Unitary2qBox, Unitary3qBox]:
+    def _get_ubox(u: np.ndarray) -> Unitary1qBox | Unitary2qBox | Unitary3qBox:
         """Return a UnitaryxqBox for a given unitary"""
         if u.shape[0] == 2:
             return Unitary1qBox(u)

--- a/pytket/extensions/qiskit/backends/crosstalk_model.py
+++ b/pytket/extensions/qiskit/backends/crosstalk_model.py
@@ -140,11 +140,8 @@ class NoisyCircuitBuilder:
     ) -> None:
         """Construct a builder to generate noisy circuit
         :param circ: the original circuit.
-        :type circ: `Circuit`
         :param N: hyperparameter N
-        :type N: float
         :param ct_params: crosstalk parameters.
-        :type ct_params: `CrosstalkParams`
         """
         self.circ = circ
         self.all_qubits = set(circ.qubits)

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -22,7 +22,6 @@ from typing import (
     Optional,
     Sequence,
     TYPE_CHECKING,
-    Union,
     Any,
 )
 from warnings import warn
@@ -465,7 +464,7 @@ class IBMQBackend(Backend):
     def process_circuits(
         self,
         circuits: Sequence[Circuit],
-        n_shots: Union[None, int, Sequence[Optional[int]]] = None,
+        n_shots: None | int | Sequence[Optional[int]] = None,
         valid_check: bool = True,
         **kwargs: KwargTypes,
     ) -> list[ResultHandle]:

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -339,7 +339,9 @@ class IBMQBackend(Backend):
         return predicates
 
     def default_compilation_pass(
-        self, optimisation_level: int = 2, placement_options: Optional[dict] = None
+        self,
+        optimisation_level: int = 2,
+        placement_options: Optional[dict[str, Any]] = None,
     ) -> BasePass:
         """
         A suggested compilation pass that will will, if possible, produce an equivalent
@@ -381,7 +383,7 @@ class IBMQBackend(Backend):
         config: QasmBackendConfiguration,
         props: Optional[BackendProperties],
         optimisation_level: int = 2,
-        placement_options: Optional[dict] = None,
+        placement_options: Optional[dict[str, Any]] = None,
     ) -> BasePass:
         backend_info = IBMQBackend._get_backend_info(config, props)
         primitive_gates = _get_primitive_gates(_tk_gate_set(config))

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -20,7 +20,6 @@ from time import sleep
 from typing import (
     cast,
     Optional,
-    Dict,
     Sequence,
     TYPE_CHECKING,
     Union,
@@ -342,7 +341,7 @@ class IBMQBackend(Backend):
         return predicates
 
     def default_compilation_pass(
-        self, optimisation_level: int = 2, placement_options: Optional[Dict] = None
+        self, optimisation_level: int = 2, placement_options: Optional[dict] = None
     ) -> BasePass:
         """
         A suggested compilation pass that will will, if possible, produce an equivalent
@@ -384,7 +383,7 @@ class IBMQBackend(Backend):
         config: QasmBackendConfiguration,
         props: Optional[BackendProperties],
         optimisation_level: int = 2,
-        placement_options: Optional[Dict] = None,
+        placement_options: Optional[dict] = None,
     ) -> BasePass:
         backend_info = IBMQBackend._get_backend_info(config, props)
         primitive_gates = _get_primitive_gates(_tk_gate_set(config))

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -24,7 +24,6 @@ from typing import (
     Dict,
     Sequence,
     TYPE_CHECKING,
-    Tuple,
     Union,
     Set,
     Any,
@@ -213,7 +212,7 @@ class IBMQBackend(Backend):
         self._monitor = monitor
 
         # cache of results keyed by job id and circuit index
-        self._ibm_res_cache: Dict[Tuple[str, int], Counter] = dict()
+        self._ibm_res_cache: Dict[tuple[str, int], Counter] = dict()
 
         if sampler_options is None:
             sampler_options = SamplerOptions()

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -19,7 +19,6 @@ import json
 from time import sleep
 from typing import (
     cast,
-    List,
     Optional,
     Dict,
     Sequence,

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -130,7 +130,7 @@ def _save_ibmq_auth(qiskit_config: Optional[QiskitConfig]) -> None:
         )
 
 
-def _get_primitive_gates(gateset: Set[OpType]) -> Set[OpType]:
+def _get_primitive_gates(gateset: set[OpType]) -> set[OpType]:
     if gateset >= {OpType.X, OpType.SX, OpType.Rz, OpType.CX}:
         return {OpType.X, OpType.SX, OpType.Rz, OpType.CX}
     elif gateset >= {OpType.X, OpType.SX, OpType.Rz, OpType.ECR}:

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -212,7 +212,7 @@ class IBMQBackend(Backend):
         self._monitor = monitor
 
         # cache of results keyed by job id and circuit index
-        self._ibm_res_cache: Dict[tuple[str, int], Counter] = dict()
+        self._ibm_res_cache: dict[tuple[str, int], Counter] = dict()
 
         if sampler_options is None:
             sampler_options = SamplerOptions()
@@ -309,7 +309,7 @@ class IBMQBackend(Backend):
         return backend_info
 
     @classmethod
-    def available_devices(cls, **kwargs: Any) -> List[BackendInfo]:
+    def available_devices(cls, **kwargs: Any) -> list[BackendInfo]:
         service: Optional[QiskitRuntimeService] = kwargs.get("service")
         if service is None:
             instance = kwargs.get("instance")
@@ -327,7 +327,7 @@ class IBMQBackend(Backend):
         return backend_info_list
 
     @property
-    def required_predicates(self) -> List[Predicate]:
+    def required_predicates(self) -> list[Predicate]:
         predicates = [
             NoSymbolsPredicate(),
             MaxNQubitsPredicate(self._backend_info.n_nodes),
@@ -483,7 +483,7 @@ class IBMQBackend(Backend):
         n_shots: Union[None, int, Sequence[Optional[int]]] = None,
         valid_check: bool = True,
         **kwargs: KwargTypes,
-    ) -> List[ResultHandle]:
+    ) -> list[ResultHandle]:
         """
         See :py:meth:`pytket.backends.Backend.process_circuits`.
 
@@ -509,7 +509,7 @@ class IBMQBackend(Backend):
             optional=False,
         )
 
-        handle_list: List[Optional[ResultHandle]] = [None] * len(circuits)
+        handle_list: list[Optional[ResultHandle]] = [None] * len(circuits)
         circuit_batches, batch_order = _batch_circuits(circuits, n_shots_list)
 
         postprocess = kwargs.get("postprocess", False)
@@ -566,7 +566,7 @@ class IBMQBackend(Backend):
         for handle in handle_list:
             assert handle is not None
             self._cache[handle] = dict()
-        return cast(List[ResultHandle], handle_list)
+        return cast(list[ResultHandle], handle_list)
 
     def _retrieve_job(self, jobid: str) -> RuntimeJob:
         return self._service.job(jobid)

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -23,7 +23,6 @@ from typing import (
     Sequence,
     TYPE_CHECKING,
     Union,
-    Set,
     Any,
 )
 from warnings import warn

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -154,21 +154,15 @@ class IBMQBackend(Backend):
     This function can also be used to set the IBMQ API token.
 
     :param backend_name: Name of the IBMQ device, e.g. `ibmq_16_melbourne`.
-    :type backend_name: str
     :param instance: String containing information about the hub/group/project.
-    :type instance: str, optional
     :param monitor: Use the IBM job monitor. Defaults to True.
-    :type monitor: bool, optional
     :raises ValueError: If no IBMQ account is loaded and none exists on the disk.
     :param service: A QiskitRuntimeService
-    :type service: Optional[QiskitRuntimeService]
     :param token: Authentication token to use the `QiskitRuntimeService`.
-    :type token: Optional[str]
     :param sampler_options: A customised `qiskit_ibm_runtime` `SamplerOptions` instance.
         See the Qiskit documentation at
         https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.SamplerOptions
         for details and default values.
-    :type sampler_options: Optional[SamplerOptions]
     """
 
     _supports_shots = False
@@ -244,11 +238,8 @@ class IBMQBackend(Backend):
         """Construct a BackendInfo from data returned by the IBMQ API.
 
         :param config: The configuration of this backend.
-        :type config: QasmBackendConfiguration
         :param props: The measured properties of this backend (not required).
-        :type props: Optional[BackendProperties]
         :return: Information about the backend.
-        :rtype: BackendInfo
         """
         characterisation = process_characterisation_from_config(config, props)
         averaged_errors = get_avg_characterisation(characterisation)
@@ -378,13 +369,10 @@ class IBMQBackend(Backend):
             - Level 2 (the default) adds more computationally intensive optimisations
               that should give the best results from execution.
 
-        :type optimisation_level: int, optional
 
         :param placement_options: Optional argument allowing the user to override
           the default settings in :py:class:`NoiseAwarePlacement`.
-        :type placement_options: Dict, optional
         :return: Compilation pass guaranteeing required predicates.
-        :rtype: BasePass
         """
         config: QasmBackendConfiguration = self._backend.configuration()
         props: Optional[BackendProperties] = self._backend.properties()

--- a/pytket/extensions/qiskit/backends/ibm_utils.py
+++ b/pytket/extensions/qiskit/backends/ibm_utils.py
@@ -16,7 +16,7 @@
 """
 
 import itertools
-from typing import Collection, Optional, Sequence, Tuple, List, TYPE_CHECKING
+from typing import Collection, Optional, Sequence, List, TYPE_CHECKING
 
 import numpy as np
 
@@ -48,7 +48,7 @@ _STATUS_MAP = {
 def _batch_circuits(
     circuits: Sequence["Circuit"],
     n_shots: Sequence[Optional[int]],
-) -> Tuple[List[Tuple[Optional[int], List["Circuit"]]], List[List[int]]]:
+) -> tuple[List[tuple[Optional[int], List["Circuit"]]], List[List[int]]]:
     """
     Groups circuits into sets of circuits with the same number of shots.
 
@@ -63,7 +63,7 @@ def _batch_circuits(
     n_shots_int = list(map(lambda x: x if x is not None else -1, n_shots))
 
     order: Collection[int] = np.argsort(n_shots_int)
-    batches: List[Tuple[Optional[int], List["Circuit"]]] = [
+    batches: List[tuple[Optional[int], List["Circuit"]]] = [
         (n, [circuits[i] for i in indices])
         for n, indices in itertools.groupby(order, key=lambda i: n_shots[i])
     ]

--- a/pytket/extensions/qiskit/backends/ibm_utils.py
+++ b/pytket/extensions/qiskit/backends/ibm_utils.py
@@ -55,9 +55,7 @@ def _batch_circuits(
     Returns a tuple of circuit batches and their ordering.
 
     :param circuits: Circuits to be grouped.
-    :type circuits: Sequence[Circuit]
     :param n_shots: Number of shots for each circuit.
-    :type n_shots: Sequence[int]
     """
     # take care of None entries
     n_shots_int = list(map(lambda x: x if x is not None else -1, n_shots))

--- a/pytket/extensions/qiskit/backends/ibm_utils.py
+++ b/pytket/extensions/qiskit/backends/ibm_utils.py
@@ -16,7 +16,7 @@
 """
 
 import itertools
-from typing import Collection, Optional, Sequence, List, TYPE_CHECKING
+from typing import Collection, Optional, Sequence, TYPE_CHECKING
 
 import numpy as np
 
@@ -48,7 +48,7 @@ _STATUS_MAP = {
 def _batch_circuits(
     circuits: Sequence["Circuit"],
     n_shots: Sequence[Optional[int]],
-) -> tuple[List[tuple[Optional[int], List["Circuit"]]], List[List[int]]]:
+) -> tuple[list[tuple[Optional[int], list["Circuit"]]], list[list[int]]]:
     """
     Groups circuits into sets of circuits with the same number of shots.
 
@@ -63,11 +63,11 @@ def _batch_circuits(
     n_shots_int = list(map(lambda x: x if x is not None else -1, n_shots))
 
     order: Collection[int] = np.argsort(n_shots_int)
-    batches: List[tuple[Optional[int], List["Circuit"]]] = [
+    batches: list[tuple[Optional[int], list["Circuit"]]] = [
         (n, [circuits[i] for i in indices])
         for n, indices in itertools.groupby(order, key=lambda i: n_shots[i])
     ]
-    batch_order: List[List[int]] = [
+    batch_order: list[list[int]] = [
         list(indices)
         for n, indices in itertools.groupby(order, key=lambda i: n_shots[i])
     ]

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -76,14 +76,14 @@ class IBMQEmulatorBackend(Backend):
         self._aer = AerBackend(noise_model=self._noise_model)
 
         # cache of results keyed by job id and circuit index
-        self._ibm_res_cache: Dict[tuple[str, int], Counter] = dict()
+        self._ibm_res_cache: dict[tuple[str, int], Counter] = dict()
 
     @property
     def backend_info(self) -> BackendInfo:
         return self._ibmq._backend_info
 
     @property
-    def required_predicates(self) -> List[Predicate]:
+    def required_predicates(self) -> list[Predicate]:
         return self._ibmq.required_predicates
 
     def default_compilation_pass(
@@ -109,7 +109,7 @@ class IBMQEmulatorBackend(Backend):
         n_shots: Union[None, int, Sequence[Optional[int]]] = None,
         valid_check: bool = True,
         **kwargs: KwargTypes,
-    ) -> List[ResultHandle]:
+    ) -> list[ResultHandle]:
         """
         See :py:meth:`pytket.backends.Backend.process_circuits`.
         Supported kwargs: `seed`, `postprocess`.

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -18,7 +18,6 @@ from typing import (
     Optional,
     List,
     Sequence,
-    Tuple,
     Union,
 )
 
@@ -77,7 +76,7 @@ class IBMQEmulatorBackend(Backend):
         self._aer = AerBackend(noise_model=self._noise_model)
 
         # cache of results keyed by job id and circuit index
-        self._ibm_res_cache: Dict[Tuple[str, int], Counter] = dict()
+        self._ibm_res_cache: Dict[tuple[str, int], Counter] = dict()
 
     @property
     def backend_info(self) -> BackendInfo:

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -22,15 +22,13 @@ from typing import (
 from qiskit_aer.noise.noise_model import NoiseModel  # type: ignore
 from qiskit_ibm_runtime import QiskitRuntimeService  # type: ignore
 
-from pytket.backends import (
-    Backend,
-    ResultHandle,
-    CircuitStatus,
-)
+from pytket.backends.backend import Backend
+from pytket.backends.status import CircuitStatus
+
 from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
-from pytket.backends.resulthandle import _ResultIdTuple
-from pytket.circuit import Circuit
+from pytket.backends.resulthandle import _ResultIdTuple, ResultHandle
+from pytket._tket.circuit import Circuit
 from pytket.passes import BasePass
 from pytket.predicates import Predicate
 from pytket.utils.results import KwargTypes

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -16,6 +16,7 @@ from collections import Counter
 from typing import (
     Optional,
     Sequence,
+    Any,
 )
 
 from qiskit_aer.noise.noise_model import NoiseModel  # type: ignore
@@ -84,7 +85,9 @@ class IBMQEmulatorBackend(Backend):
         return self._ibmq.required_predicates
 
     def default_compilation_pass(
-        self, optimisation_level: int = 2, placement_options: Optional[dict] = None
+        self,
+        optimisation_level: int = 2,
+        placement_options: Optional[dict[str, Any]] = None,
     ) -> BasePass:
         """
         See documentation for :py:meth:`IBMQBackend.default_compilation_pass`.

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -16,7 +16,6 @@ from collections import Counter
 from typing import (
     Optional,
     Sequence,
-    Union,
 )
 
 from qiskit_aer.noise.noise_model import NoiseModel  # type: ignore
@@ -104,7 +103,7 @@ class IBMQEmulatorBackend(Backend):
     def process_circuits(
         self,
         circuits: Sequence[Circuit],
-        n_shots: Union[None, int, Sequence[Optional[int]]] = None,
+        n_shots: None | int | Sequence[Optional[int]] = None,
         valid_check: bool = True,
         **kwargs: KwargTypes,
     ) -> list[ResultHandle]:

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -16,7 +16,6 @@ from collections import Counter
 from typing import (
     Dict,
     Optional,
-    List,
     Sequence,
     Union,
 )

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -14,7 +14,6 @@
 
 from collections import Counter
 from typing import (
-    Dict,
     Optional,
     Sequence,
     Union,
@@ -86,7 +85,7 @@ class IBMQEmulatorBackend(Backend):
         return self._ibmq.required_predicates
 
     def default_compilation_pass(
-        self, optimisation_level: int = 2, placement_options: Optional[Dict] = None
+        self, optimisation_level: int = 2, placement_options: Optional[dict] = None
     ) -> BasePass:
         """
         See documentation for :py:meth:`IBMQBackend.default_compilation_pass`.

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -28,7 +28,7 @@ from pytket.backends.status import CircuitStatus
 from pytket.backends.backendinfo import BackendInfo
 from pytket.backends.backendresult import BackendResult
 from pytket.backends.resulthandle import _ResultIdTuple, ResultHandle
-from pytket._tket.circuit import Circuit
+from pytket.circuit import Circuit
 from pytket.passes import BasePass
 from pytket.predicates import Predicate
 from pytket.utils.results import KwargTypes

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -207,7 +207,7 @@ _gate_str_2_optype_rev = {v: k for k, v in _gate_str_2_optype.items()}
 _gate_str_2_optype_rev[OpType.Unitary1qBox] = "unitary"
 
 
-def _tk_gate_set(config: QasmBackendConfiguration) -> Set[OpType]:
+def _tk_gate_set(config: QasmBackendConfiguration) -> set[OpType]:
     """Set of tket gate types supported by the qiskit backend"""
     if config.simulator:
         gate_set = {

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -18,7 +18,6 @@
 from collections import defaultdict
 from typing import (
     Callable,
-    Dict,
     Optional,
     Union,
     Any,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -19,7 +19,6 @@ from collections import defaultdict
 from typing import (
     Callable,
     Dict,
-    List,
     Optional,
     Union,
     Any,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -26,7 +26,6 @@ from typing import (
     Iterable,
     cast,
     Set,
-    Tuple,
     TypeVar,
     TYPE_CHECKING,
 )
@@ -611,7 +610,7 @@ def append_tk_command_to_qiskit(
     qregmap: Dict[str, QuantumRegister],
     cregmap: Dict[str, ClassicalRegister],
     symb_map: Dict[Parameter, sympy.Symbol],
-    range_preds: Dict[Bit, Tuple[List["UnitID"], int]],
+    range_preds: Dict[Bit, tuple[List["UnitID"], int]],
 ) -> InstructionSet:
     optype = op.type
     if optype == OpType.Measure:
@@ -842,7 +841,7 @@ def tk_to_qiskit(
             cregmap.update({c_reg.name: qis_reg})
             qcirc.add_register(qis_reg)
     symb_map = {Parameter(str(s)): s for s in tkc.free_symbols()}
-    range_preds: Dict[Bit, Tuple[List["UnitID"], int]] = dict()
+    range_preds: Dict[Bit, tuple[List["UnitID"], int]] = dict()
 
     # Apply a rebase to the set of pytket gates which have replacements in qiskit
     supported_gate_rebase.apply(tkc)
@@ -1002,7 +1001,7 @@ def get_avg_characterisation(
 
     node_errors = cast(Dict[Node, Dict[OpType, float]], characterisation["NodeErrors"])
     link_errors = cast(
-        Dict[Tuple[Node, Node], Dict[OpType, float]], characterisation["EdgeErrors"]
+        Dict[tuple[Node, Node], Dict[OpType, float]], characterisation["EdgeErrors"]
     )
     readout_errors = cast(
         Dict[Node, List[List[float]]], characterisation["ReadoutErrors"]

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -183,7 +183,7 @@ _known_gate_rev_phase[OpType.V] = (qiskit_gates.SXGate, -0.25)
 _known_gate_rev_phase[OpType.Vdg] = (qiskit_gates.SXdgGate, 0.25)
 
 # use minor signature hacks to figure out the string names of qiskit Gate objects
-_gate_str_2_optype: Dict[str, OpType] = dict()
+_gate_str_2_optype: dict[str, OpType] = dict()
 for gate, optype in _known_qiskit_gate.items():
     if gate in (
         UnitaryGate,
@@ -225,7 +225,7 @@ def _tk_gate_set(config: QasmBackendConfiguration) -> Set[OpType]:
         }
 
 
-def _qpo_from_peg(peg: PauliEvolutionGate, qubits: List[Qubit]) -> QubitPauliOperator:
+def _qpo_from_peg(peg: PauliEvolutionGate, qubits: list[Qubit]) -> QubitPauliOperator:
     op = peg.operator
     t = peg.params[0]
     qpodict = {}
@@ -292,8 +292,8 @@ def _string_to_circuit(
 class CircuitBuilder:
     def __init__(
         self,
-        qregs: List[QuantumRegister],
-        cregs: Optional[List[ClassicalRegister]] = None,
+        qregs: list[QuantumRegister],
+        cregs: Optional[list[ClassicalRegister]] = None,
         name: Optional[str] = None,
         phase: Optional[sympy.Expr] = None,
     ):
@@ -325,7 +325,7 @@ class CircuitBuilder:
         self,
         num_ctrl_qubits: Optional[int],
         ctrl_state: Optional[Union[str, int]],
-        qargs: List["Qubit"],
+        qargs: list["Qubit"],
     ) -> None:
         if ctrl_state is not None:
             assert isinstance(num_ctrl_qubits, int)
@@ -513,8 +513,8 @@ class CircuitBuilder:
 def add_qiskit_unitary_to_tkc(
     tkc: Circuit,
     u_gate: UnitaryGate,
-    qubits: List[Qubit],
-    condition_kwargs: Dict[str, Any],
+    qubits: list[Qubit],
+    condition_kwargs: dict[str, Any],
 ) -> None:
     # Note reversal of qubits, to account for endianness (pytket unitaries
     # are ILO-BE == DLO-LE; qiskit unitaries are ILO-LE == DLO-BE).
@@ -588,7 +588,7 @@ def param_to_tk(p: Union[float, ParameterExpression]) -> sympy.Expr:
 
 
 def param_to_qiskit(
-    p: sympy.Expr, symb_map: Dict[Parameter, sympy.Symbol]
+    p: sympy.Expr, symb_map: dict[Parameter, sympy.Symbol]
 ) -> Union[float, ParameterExpression]:
     ppi = p * sympy.pi
     if len(ppi.free_symbols) == 0:
@@ -598,19 +598,19 @@ def param_to_qiskit(
 
 
 def _get_params(
-    op: Op, symb_map: Dict[Parameter, sympy.Symbol]
-) -> List[Union[float, ParameterExpression]]:
+    op: Op, symb_map: dict[Parameter, sympy.Symbol]
+) -> list[Union[float, ParameterExpression]]:
     return [param_to_qiskit(p, symb_map) for p in op.params]
 
 
 def append_tk_command_to_qiskit(
     op: "Op",
-    args: List["UnitID"],
+    args: list["UnitID"],
     qcirc: QuantumCircuit,
-    qregmap: Dict[str, QuantumRegister],
-    cregmap: Dict[str, ClassicalRegister],
-    symb_map: Dict[Parameter, sympy.Symbol],
-    range_preds: Dict[Bit, tuple[List["UnitID"], int]],
+    qregmap: dict[str, QuantumRegister],
+    cregmap: dict[str, ClassicalRegister],
+    symb_map: dict[Parameter, sympy.Symbol],
+    range_preds: dict[Bit, tuple[list["UnitID"], int]],
 ) -> InstructionSet:
     optype = op.type
     if optype == OpType.Measure:
@@ -820,7 +820,7 @@ def tk_to_qiskit(
     if replace_implicit_swaps:
         tkc.replace_implicit_wire_swaps()
     qcirc = QuantumCircuit(name=tkc.name)
-    qreg_sizes: Dict[str, int] = {}
+    qreg_sizes: dict[str, int] = {}
     for qb in tkc.qubits:
         if len(qb.index) != 1:
             raise NotImplementedError("Qiskit registers must use a single index")
@@ -841,7 +841,7 @@ def tk_to_qiskit(
             cregmap.update({c_reg.name: qis_reg})
             qcirc.add_register(qis_reg)
     symb_map = {Parameter(str(s)): s for s in tkc.free_symbols()}
-    range_preds: Dict[Bit, tuple[List["UnitID"], int]] = dict()
+    range_preds: dict[Bit, tuple[list["UnitID"], int]] = dict()
 
     # Apply a rebase to the set of pytket gates which have replacements in qiskit
     supported_gate_rebase.apply(tkc)
@@ -872,7 +872,7 @@ def tk_to_qiskit(
     return qcirc
 
 
-def process_characterisation(backend: "BackendV1") -> Dict[str, Any]:
+def process_characterisation(backend: "BackendV1") -> dict[str, Any]:
     """Convert a :py:class:`qiskit.providers.backend.BackendV1` to a dictionary
      containing device Characteristics
 
@@ -888,7 +888,7 @@ def process_characterisation(backend: "BackendV1") -> Dict[str, Any]:
 
 def process_characterisation_from_config(
     config: QasmBackendConfiguration, properties: Optional[BackendProperties]
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Obtain a dictionary containing device Characteristics given config and props.
 
     :param config: A IBMQ configuration object
@@ -963,14 +963,14 @@ def process_characterisation_from_config(
     K1 = TypeVar("K1")
     K2 = TypeVar("K2")
     V = TypeVar("V")
-    convert_keys_t = Callable[[Callable[[K1], K2], Dict[K1, V]], Dict[K2, V]]
+    convert_keys_t = Callable[[Callable[[K1], K2], dict[K1, V]], dict[K2, V]]
     # convert qubits to architecture Nodes
     convert_keys: convert_keys_t = lambda f, d: {f(k): v for k, v in d.items()}
     node_errors = convert_keys(lambda q: Node(q), node_errors)
     link_errors = convert_keys(lambda p: (Node(p[0]), Node(p[1])), link_errors)
     readout_errors = convert_keys(lambda q: Node(q), readout_errors)
 
-    characterisation: Dict[str, Any] = dict()
+    characterisation: dict[str, Any] = dict()
     characterisation["NodeErrors"] = node_errors
     characterisation["EdgeErrors"] = link_errors
     characterisation["ReadoutErrors"] = readout_errors
@@ -984,8 +984,8 @@ def process_characterisation_from_config(
 
 
 def get_avg_characterisation(
-    characterisation: Dict[str, Any]
-) -> Dict[str, Dict[Node, float]]:
+    characterisation: dict[str, Any]
+) -> dict[str, dict[Node, float]]:
     """
     Convert gate-specific characterisation into readout, one- and two-qubit errors
 
@@ -996,19 +996,19 @@ def get_avg_characterisation(
     K = TypeVar("K")
     V1 = TypeVar("V1")
     V2 = TypeVar("V2")
-    map_values_t = Callable[[Callable[[V1], V2], Dict[K, V1]], Dict[K, V2]]
+    map_values_t = Callable[[Callable[[V1], V2], dict[K, V1]], dict[K, V2]]
     map_values: map_values_t = lambda f, d: {k: f(v) for k, v in d.items()}
 
-    node_errors = cast(Dict[Node, Dict[OpType, float]], characterisation["NodeErrors"])
+    node_errors = cast(dict[Node, dict[OpType, float]], characterisation["NodeErrors"])
     link_errors = cast(
-        Dict[tuple[Node, Node], Dict[OpType, float]], characterisation["EdgeErrors"]
+        dict[tuple[Node, Node], dict[OpType, float]], characterisation["EdgeErrors"]
     )
     readout_errors = cast(
-        Dict[Node, List[List[float]]], characterisation["ReadoutErrors"]
+        dict[Node, list[list[float]]], characterisation["ReadoutErrors"]
     )
 
-    avg: Callable[[Dict[Any, float]], float] = lambda xs: sum(xs.values()) / len(xs)
-    avg_mat: Callable[[List[List[float]]], float] = (
+    avg: Callable[[dict[Any, float]], float] = lambda xs: sum(xs.values()) / len(xs)
+    avg_mat: Callable[[list[list[float]]], float] = (
         lambda xs: (xs[0][1] + xs[1][0]) / 2.0
     )
     avg_readout_errors = map_values(avg_mat, readout_errors)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -549,15 +549,12 @@ def qiskit_to_tk(qcirc: QuantumCircuit, preserve_param_uuid: bool = False) -> Ci
     Converts a qiskit :py:class:`qiskit.QuantumCircuit` to a pytket :py:class:`Circuit`.
 
     :param qcirc: A circuit to be converted
-    :type qcirc: QuantumCircuit
     :param preserve_param_uuid: Whether to preserve symbolic Parameter uuids
         by appending them to the tket Circuit symbol names as "_UUID:<uuid>".
         This can be useful if you want to reassign Parameters after conversion
         to tket and back, as it is necessary for Parameter object equality
         to be preserved.
-    :type preserve_param_uuid: bool
     :return: The converted circuit
-    :rtype: Circuit
     """
     circ_name = qcirc.name
     # Parameter uses a hidden _uuid for equality check
@@ -809,12 +806,9 @@ def tk_to_qiskit(
     circuit will be returned using the tket gates which are supported in qiskit.
 
     :param tkcirc: A :py:class:`Circuit` to be converted
-    :type tkcirc: Circuit
     :param replace_implicit_swaps: Implement implicit permutation by adding SWAPs
         to the end of the circuit.
-    :type replace_implicit_swaps: bool
     :return: The converted circuit
-    :rtype: QuantumCircuit
     """
     tkc = tkcirc.copy()  # Make a local copy of tkcirc
     if replace_implicit_swaps:
@@ -877,9 +871,7 @@ def process_characterisation(backend: "BackendV1") -> dict[str, Any]:
      containing device Characteristics
 
     :param backend: A backend to be converted
-    :type backend: BackendV1
     :return: A dictionary containing device characteristics
-    :rtype: dict
     """
     config = backend.configuration()
     props = backend.properties()
@@ -892,11 +884,8 @@ def process_characterisation_from_config(
     """Obtain a dictionary containing device Characteristics given config and props.
 
     :param config: A IBMQ configuration object
-    :type config: QasmBackendConfiguration
     :param properties: An optional IBMQ properties object
-    :type properties: Optional[BackendProperties]
     :return: A dictionary containing device characteristics
-    :rtype: dict
     """
 
     # TODO explicitly check for and separate 1 and 2 qubit gates

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -321,7 +321,7 @@ class CircuitBuilder:
     def add_xs(
         self,
         num_ctrl_qubits: Optional[int],
-        ctrl_state: Optional[Union[str, int]],
+        ctrl_state: Optional[str | int],
         qargs: list["Qubit"],
     ) -> None:
         if ctrl_state is not None:
@@ -570,7 +570,7 @@ def qiskit_to_tk(qcirc: QuantumCircuit, preserve_param_uuid: bool = False) -> Ci
     return builder.circuit()
 
 
-def param_to_tk(p: Union[float, ParameterExpression]) -> sympy.Expr:
+def param_to_tk(p: float | ParameterExpression) -> sympy.Expr:
     if isinstance(p, ParameterExpression):
         symexpr = p._symbol_expr
         try:
@@ -583,7 +583,7 @@ def param_to_tk(p: Union[float, ParameterExpression]) -> sympy.Expr:
 
 def param_to_qiskit(
     p: sympy.Expr, symb_map: dict[Parameter, sympy.Symbol]
-) -> Union[float, ParameterExpression]:
+) -> float | ParameterExpression:
     ppi = p * sympy.pi
     if len(ppi.free_symbols) == 0:
         return float(ppi.evalf())
@@ -593,7 +593,7 @@ def param_to_qiskit(
 
 def _get_params(
     op: Op, symb_map: dict[Parameter, sympy.Symbol]
-) -> list[Union[float, ParameterExpression]]:
+) -> list[float | ParameterExpression]:
     return [param_to_qiskit(p, symb_map) for p in op.params]
 
 
@@ -899,7 +899,7 @@ def process_characterisation_from_config(
     n_qubits = config.n_qubits
     if coupling_map is None:
         # Assume full connectivity
-        arc: Union[FullyConnected, Architecture] = FullyConnected(n_qubits)
+        arc: FullyConnected | Architecture = FullyConnected(n_qubits)
     else:
         arc = Architecture(coupling_map)
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -23,7 +23,6 @@ from typing import (
     Any,
     Iterable,
     cast,
-    Set,
     TypeVar,
     TYPE_CHECKING,
 )

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -18,7 +18,6 @@ from typing import (
     Sequence,
     Set,
     Optional,
-    Dict,
     Any,
 )
 from collections import Counter, defaultdict

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -35,17 +35,17 @@ from pytket.backends.backendresult import BackendResult
 from pytket.utils.outcomearray import OutcomeArray
 
 
-def _get_registers_from_uids(uids: List[UnitID]) -> Dict[str, Set[UnitID]]:
-    registers: Dict[str, Set[UnitID]] = defaultdict(set)
+def _get_registers_from_uids(uids: list[UnitID]) -> dict[str, Set[UnitID]]:
+    registers: dict[str, Set[UnitID]] = defaultdict(set)
     for uid in uids:
         registers[uid.reg_name].add(uid)
     return registers
 
 
-LabelsType = List[tuple[str, int]]
+LabelsType = list[tuple[str, int]]
 
 
-def _get_header_info(uids: List[UnitID]) -> tuple[LabelsType, LabelsType]:
+def _get_header_info(uids: list[UnitID]) -> tuple[LabelsType, LabelsType]:
     registers = _get_registers_from_uids(uids)
     reg_sizes = [(name, max(uids).index[0] + 1) for name, uids in registers.items()]
     reg_labels = [
@@ -55,7 +55,7 @@ def _get_header_info(uids: List[UnitID]) -> tuple[LabelsType, LabelsType]:
     return reg_sizes, reg_labels
 
 
-def _qiskit_ordered_uids(uids: List[UnitID]) -> List[UnitID]:
+def _qiskit_ordered_uids(uids: list[UnitID]) -> list[UnitID]:
     registers = _get_registers_from_uids(uids)
     names = sorted(registers.keys())
     return [uid for name in names for uid in sorted(registers[name], reverse=True)]
@@ -150,11 +150,11 @@ def qiskit_result_to_backendresult(res: Result) -> Iterator[BackendResult]:
 
 def backendresult_to_qiskit_resultdata(
     res: BackendResult,
-    cbits: List[UnitID],
-    qbits: List[UnitID],
-    final_map: Optional[Dict[UnitID, UnitID]],
-) -> Dict[str, Any]:
-    data: Dict[str, Any] = dict()
+    cbits: list[UnitID],
+    qbits: list[UnitID],
+    final_map: Optional[dict[UnitID, UnitID]],
+) -> dict[str, Any]:
+    data: dict[str, Any] = dict()
     if res.contains_state_results:
         qbits = _qiskit_ordered_uids(qbits)
         qbits.sort(reverse=True)

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -14,7 +14,6 @@
 
 
 from typing import (
-    List,
     Iterator,
     Sequence,
     Set,

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -35,8 +35,8 @@ from pytket.backends.backendresult import BackendResult
 from pytket.utils.outcomearray import OutcomeArray
 
 
-def _get_registers_from_uids(uids: list[UnitID]) -> dict[str, Set[UnitID]]:
-    registers: dict[str, Set[UnitID]] = defaultdict(set)
+def _get_registers_from_uids(uids: list[UnitID]) -> dict[str, set[UnitID]]:
+    registers: dict[str, set[UnitID]] = defaultdict(set)
     for uid in uids:
         registers[uid.reg_name].add(uid)
     return registers

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -16,7 +16,6 @@
 from typing import (
     Iterator,
     Sequence,
-    Set,
     Optional,
     Any,
 )

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -18,7 +18,6 @@ from typing import (
     Iterator,
     Sequence,
     Set,
-    Tuple,
     Optional,
     Dict,
     Any,
@@ -43,10 +42,10 @@ def _get_registers_from_uids(uids: List[UnitID]) -> Dict[str, Set[UnitID]]:
     return registers
 
 
-LabelsType = List[Tuple[str, int]]
+LabelsType = List[tuple[str, int]]
 
 
-def _get_header_info(uids: List[UnitID]) -> Tuple[LabelsType, LabelsType]:
+def _get_header_info(uids: List[UnitID]) -> tuple[LabelsType, LabelsType]:
     registers = _get_registers_from_uids(uids)
     reg_sizes = [(name, max(uids).index[0] + 1) for name, uids in registers.items()]
     reg_labels = [

--- a/pytket/extensions/qiskit/tket_backend.py
+++ b/pytket/extensions/qiskit/tket_backend.py
@@ -70,10 +70,8 @@ class TketBackend(BackendV1):
         """Create a new :py:class:`TketBackend` from a :py:class:`Backend`.
 
         :param backend: The device or simulator to wrap up
-        :type backend: Backend
         :param comp_pass: The (optional) tket compilation pass to apply to each circuit
          before submitting to the :py:class:`Backend`, defaults to None
-        :type comp_pass: Optional[BasePass], optional
         """
         arch = backend.backend_info.architecture if backend.backend_info else None
         coupling: Optional[list[list[Any]]]

--- a/pytket/extensions/qiskit/tket_backend.py
+++ b/pytket/extensions/qiskit/tket_backend.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union, Any
+from typing import Optional, Any
 from qiskit.circuit.quantumcircuit import QuantumCircuit  # type: ignore
 from qiskit.providers.backend import BackendV1  # type: ignore
 from qiskit.providers.models import QasmBackendConfiguration  # type: ignore
@@ -118,7 +118,7 @@ class TketBackend(BackendV1):
         return Options(shots=None, memory=False)
 
     def run(
-        self, run_input: Union[QuantumCircuit, list[QuantumCircuit]], **options: Any
+        self, run_input: QuantumCircuit | list[QuantumCircuit], **options: Any
     ) -> TketJob:
         if isinstance(run_input, QuantumCircuit):
             run_input = [run_input]

--- a/pytket/extensions/qiskit/tket_backend.py
+++ b/pytket/extensions/qiskit/tket_backend.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, List, Union, Any
+from typing import Optional, Union, Any
 from qiskit.circuit.quantumcircuit import QuantumCircuit  # type: ignore
 from qiskit.providers.backend import BackendV1  # type: ignore
 from qiskit.providers.models import QasmBackendConfiguration  # type: ignore
@@ -30,7 +30,7 @@ from pytket.predicates import (
 from pytket.architecture import FullyConnected
 
 
-def _extract_basis_gates(backend: Backend) -> List[str]:
+def _extract_basis_gates(backend: Backend) -> list[str]:
     for pred in backend.required_predicates:
         if type(pred) == GateSetPredicate:
             return [
@@ -76,7 +76,7 @@ class TketBackend(BackendV1):
         :type comp_pass: Optional[BasePass], optional
         """
         arch = backend.backend_info.architecture if backend.backend_info else None
-        coupling: Optional[List[List[Any]]]
+        coupling: Optional[list[list[Any]]]
         if isinstance(arch, FullyConnected):
             coupling = [
                 [n1.index[0], n2.index[0]]
@@ -120,7 +120,7 @@ class TketBackend(BackendV1):
         return Options(shots=None, memory=False)
 
     def run(
-        self, run_input: Union[QuantumCircuit, List[QuantumCircuit]], **options: Any
+        self, run_input: Union[QuantumCircuit, list[QuantumCircuit]], **options: Any
     ) -> TketJob:
         if isinstance(run_input, QuantumCircuit):
             run_input = [run_input]

--- a/pytket/extensions/qiskit/tket_job.py
+++ b/pytket/extensions/qiskit/tket_job.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List, Optional, Any, TYPE_CHECKING, Union, cast
+from typing import Optional, Any, TYPE_CHECKING, Union, cast
 from qiskit.providers import JobStatus, JobV1  # type: ignore
 from qiskit.result import Result  # type: ignore
 from pytket.backends import ResultHandle, StatusEnum

--- a/pytket/extensions/qiskit/tket_job.py
+++ b/pytket/extensions/qiskit/tket_job.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List, Dict, Optional, Any, TYPE_CHECKING, Union, cast
+from typing import List, Optional, Any, TYPE_CHECKING, Union, cast
 from qiskit.providers import JobStatus, JobV1  # type: ignore
 from qiskit.result import Result  # type: ignore
 from pytket.backends import ResultHandle, StatusEnum
@@ -31,8 +31,8 @@ if TYPE_CHECKING:
 @dataclass
 class JobInfo:
     circuit_name: str
-    qbits: List[Qubit]
-    cbits: List[Bit]
+    qbits: list[Qubit]
+    cbits: list[Bit]
     n_shots: Optional[int]
 
 
@@ -43,9 +43,9 @@ class TketJob(JobV1):
     def __init__(
         self,
         backend: "TketBackend",
-        handles: List[ResultHandle],
-        jobinfos: List[JobInfo],
-        final_maps: Union[List[None], List[Dict[UnitID, UnitID]]],
+        handles: list[ResultHandle],
+        jobinfos: list[JobInfo],
+        final_maps: Union[list[None], list[dict[UnitID, UnitID]]],
     ):
         """Initializes the asynchronous job."""
 

--- a/pytket/extensions/qiskit/tket_job.py
+++ b/pytket/extensions/qiskit/tket_job.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Optional, Any, TYPE_CHECKING, Union, cast
+from typing import Optional, Any, TYPE_CHECKING, cast
 from qiskit.providers import JobStatus, JobV1  # type: ignore
 from qiskit.result import Result  # type: ignore
 from pytket.backends import ResultHandle, StatusEnum
@@ -45,7 +45,7 @@ class TketJob(JobV1):
         backend: "TketBackend",
         handles: list[ResultHandle],
         jobinfos: list[JobInfo],
-        final_maps: Union[list[None], list[dict[UnitID, UnitID]]],
+        final_maps: list[None] | list[dict[UnitID, UnitID]],
     ):
         """Initializes the asynchronous job."""
 

--- a/pytket/extensions/qiskit/tket_pass.py
+++ b/pytket/extensions/qiskit/tket_pass.py
@@ -40,7 +40,6 @@ class TketPass(TransformationPass):
         :py:class:`Circuit`. `tket_pass` will be run and the result is converted back.
 
         :param tket_pass: The pytket compiler pass to run
-        :type tket_pass: BasePass
         """
         qBasePass.__init__(self)
         self._pass = tket_pass
@@ -90,9 +89,7 @@ class TketAutoPass(TketPass):
             compilation. Level 0 just solves the device constraints without
             optimising. Level 1 additionally performs some light optimisations.
             Level 2 adds more computationally intensive optimisations. Defaults to 2.
-        :type optimisation_level: int, optional
         :param token: Authentication token to use the `QiskitRuntimeService`.
-        :type token: Optional[str]
         """
         if isinstance(backend, AerSimulator):
             tk_backend = self._aer_backend_map[backend.name]()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -14,7 +14,7 @@
 import json
 import os
 from collections import Counter
-from typing import Dict, cast
+from typing import cast
 import math
 import cmath
 from hypothesis import given, strategies
@@ -323,8 +323,8 @@ def test_process_characterisation_complete_noise_model() -> None:
     back = AerBackend(my_noise_model)
     char = back.backend_info.get_misc("characterisation")
 
-    node_errors = cast(Dict, back.backend_info.all_node_gate_errors)
-    link_errors = cast(Dict, back.backend_info.all_edge_gate_errors)
+    node_errors = cast(dict, back.backend_info.all_node_gate_errors)
+    link_errors = cast(dict, back.backend_info.all_edge_gate_errors)
     arch = back.backend_info.architecture
     assert node_errors is not None
     assert link_errors is not None
@@ -346,7 +346,7 @@ def test_process_characterisation_complete_noise_model() -> None:
     assert (
         round(link_errors[(arch.nodes[1], arch.nodes[0])][OpType.CX], 8) == 0.80859375
     )
-    readout_errors = cast(Dict, back.backend_info.all_readout_errors)
+    readout_errors = cast(dict, back.backend_info.all_readout_errors)
     assert readout_errors[arch.nodes[0]] == [
         [0.8, 0.2],
         [0.2, 0.8],
@@ -381,9 +381,9 @@ def test_process_model() -> None:
     assert "characterisation" in b.backend_info.misc
     assert "GenericOneQubitQErrors" in b.backend_info.misc["characterisation"]
     assert "GenericTwoQubitQErrors" in b.backend_info.misc["characterisation"]
-    node_gate_errors = cast(Dict, b.backend_info.all_node_gate_errors)
+    node_gate_errors = cast(dict, b.backend_info.all_node_gate_errors)
     assert nodes[3] in node_gate_errors
-    edge_gate_errors = cast(Dict, b.backend_info.all_edge_gate_errors)
+    edge_gate_errors = cast(dict, b.backend_info.all_edge_gate_errors)
     assert (nodes[7], nodes[8]) in edge_gate_errors
 
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -974,7 +974,7 @@ def test_compile_x(brisbane_backend: IBMQBackend) -> None:
         assert c1.n_gates == 1
 
 
-def lift_perm(p: Dict[int, int]) -> np.ndarray:
+def lift_perm(p: dict[int, int]) -> np.ndarray:
     """
     Given a permutation of {0,1,...,n-1} return the 2^n by 2^n permuation matrix
     representing the permutation of qubits (big-endian convention).

--- a/tests/mock_pytket_backend.py
+++ b/tests/mock_pytket_backend.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Optional, Union, List, Sequence, Set, cast
+from typing import Optional, Union, Sequence, Set, cast
 import json
 
 from pytket.circuit import Circuit, OpType
@@ -49,7 +49,7 @@ class MockShotBackend(Backend):
             self._gate_set = {OpType.CX, OpType.U3}
 
     @property
-    def required_predicates(self) -> List[Predicate]:
+    def required_predicates(self) -> list[Predicate]:
         """Returns a GateSetPredicate constructed with the given gateset."""
         return [GateSetPredicate(self._gate_set)]
 
@@ -82,7 +82,7 @@ class MockShotBackend(Backend):
         n_shots: Optional[Union[int, Sequence[int]]] = None,
         valid_check: bool = True,
         **kwargs: KwargTypes,
-    ) -> List[ResultHandle]:
+    ) -> list[ResultHandle]:
         """Mock processing the circuits."""
         handles = []
         for c in circuits:

--- a/tests/mock_pytket_backend.py
+++ b/tests/mock_pytket_backend.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Optional, Union, Sequence, cast
+from typing import Optional, Sequence, cast
 import json
 
 from pytket.circuit import Circuit, OpType
@@ -31,7 +31,7 @@ from pytket.utils.outcomearray import OutcomeArray
 class MockShotBackend(Backend):
     def __init__(
         self,
-        arch: Optional[Union[Architecture, FullyConnected]] = None,
+        arch: Optional[Architecture | FullyConnected] = None,
         gate_set: Optional[set[OpType]] = None,
     ):
         """Mock shot backend for testing qiskit embedding. This should only be used
@@ -77,7 +77,7 @@ class MockShotBackend(Backend):
     def process_circuits(
         self,
         circuits: Sequence[Circuit],
-        n_shots: Optional[Union[int, Sequence[int]]] = None,
+        n_shots: Optional[int | Sequence[int]] = None,
         valid_check: bool = True,
         **kwargs: KwargTypes,
     ) -> list[ResultHandle]:

--- a/tests/mock_pytket_backend.py
+++ b/tests/mock_pytket_backend.py
@@ -37,9 +37,7 @@ class MockShotBackend(Backend):
         """Mock shot backend for testing qiskit embedding. This should only be used
         in conjunction with the TketBackend. The readout bitstring will always be 1s.
         :param arch: The backend architecture
-        :type arch: Optional[Union[Architecture, FullyConnected]]
         :param gate_set: The supported gateset, default to {OpType.CX, OpType.U3}
-        :type gate_set: Optional[set[OpType]]
         """
         self._id = 0
         self._arch = arch

--- a/tests/mock_pytket_backend.py
+++ b/tests/mock_pytket_backend.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing import Optional, Union, Sequence, Set, cast
+from typing import Optional, Union, Sequence, cast
 import json
 
 from pytket.circuit import Circuit, OpType
@@ -32,14 +32,14 @@ class MockShotBackend(Backend):
     def __init__(
         self,
         arch: Optional[Union[Architecture, FullyConnected]] = None,
-        gate_set: Optional[Set[OpType]] = None,
+        gate_set: Optional[set[OpType]] = None,
     ):
         """Mock shot backend for testing qiskit embedding. This should only be used
         in conjunction with the TketBackend. The readout bitstring will always be 1s.
         :param arch: The backend architecture
         :type arch: Optional[Union[Architecture, FullyConnected]]
         :param gate_set: The supported gateset, default to {OpType.CX, OpType.U3}
-        :type gate_set: Optional[Set[OpType]]
+        :type gate_set: Optional[set[OpType]]
         """
         self._id = 0
         self._arch = arch

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -571,7 +571,7 @@ def test_convert_result() -> None:
 
 
 def add_x(
-    qbit: int, qr: QuantumRegister, circuits: List[Union[Circuit, QuantumCircuit]]
+    qbit: int, qr: QuantumRegister, circuits: list[Union[Circuit, QuantumCircuit]]
 ) -> None:
     """Add an x gate to each circuit in a list,
     each one being either a tket or qiskit circuit."""
@@ -584,9 +584,9 @@ def add_x(
 
 def add_cnry(
     param: float,
-    qbits: List[int],
+    qbits: list[int],
     qr: QuantumRegister,
-    circuits: List[Union[Circuit, QuantumCircuit]],
+    circuits: list[Union[Circuit, QuantumCircuit]],
 ) -> None:
     """Add a CnRy gate to each circuit in a list,
     each one being either a tket or qiskit circuit."""
@@ -603,7 +603,7 @@ def add_cnry(
             circ.append(new_gate, [qr[nn] for nn in qbits])
 
 
-def assert_tket_circuits_identical(circuits: List[Circuit]) -> None:
+def assert_tket_circuits_identical(circuits: list[Circuit]) -> None:
     """Apart from the circuit names and qubit labels, assert that
     all circuits in the list are identical (i.e., identical gates), not just equivalent
     (having the same unitary matrix)."""
@@ -624,7 +624,7 @@ def assert_tket_circuits_identical(circuits: List[Circuit]) -> None:
 
 
 def assert_equivalence(
-    circuits: List[Union[Circuit, QuantumCircuit]],
+    circuits: list[Union[Circuit, QuantumCircuit]],
     require_qk_conversions_equality: bool = True,
     require_tk_equality: bool = True,
 ) -> None:

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import os
 from collections import Counter
-from typing import Union
 from math import pi
 import pytest
 from sympy import Symbol
@@ -571,7 +570,7 @@ def test_convert_result() -> None:
 
 
 def add_x(
-    qbit: int, qr: QuantumRegister, circuits: list[Union[Circuit, QuantumCircuit]]
+    qbit: int, qr: QuantumRegister, circuits: list[Circuit | QuantumCircuit]
 ) -> None:
     """Add an x gate to each circuit in a list,
     each one being either a tket or qiskit circuit."""
@@ -586,7 +585,7 @@ def add_cnry(
     param: float,
     qbits: list[int],
     qr: QuantumRegister,
-    circuits: list[Union[Circuit, QuantumCircuit]],
+    circuits: list[Circuit | QuantumCircuit],
 ) -> None:
     """Add a CnRy gate to each circuit in a list,
     each one being either a tket or qiskit circuit."""
@@ -624,7 +623,7 @@ def assert_tket_circuits_identical(circuits: list[Circuit]) -> None:
 
 
 def assert_equivalence(
-    circuits: list[Union[Circuit, QuantumCircuit]],
+    circuits: list[Circuit | QuantumCircuit],
     require_qk_conversions_equality: bool = True,
     require_tk_equality: bool = True,
 ) -> None:

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 from collections import Counter
-from typing import List, Union
+from typing import Union
 from math import pi
 import pytest
 from sympy import Symbol

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import os
 from collections import Counter
-from typing import List, Set, Union
+from typing import List, Union
 from math import pi
 import pytest
 from sympy import Symbol
@@ -640,7 +640,7 @@ def assert_equivalence(
     tk_circuits = []
 
     # We want unique circuit names, otherwise it confuses the Qiskit backend.
-    names: Set[str] = set()
+    names: set[str] = set()
     for nn in range(len(circuits)):
         if isinstance(circuits[nn], Circuit):
             if require_tk_equality:


### PR DESCRIPTION
# Description

Used python 3.10+ types everywhere now that only 3.10+ versions of python are supported.

Some examples
* use `|` rather than `Union`
* using `list` rather than `typing.List`. `dict` rather than `typing.Dict` etc.

If we want to do this for other repos we can use [pyupgrade](https://github.com/asottile/pyupgrade) to automate most of this.

Also removed some redundant type declarations for sphinx e.g. `:type` and `:rtype`. the [sphinx-autodoc-typehints](https://github.com/tox-dev/sphinx-autodoc-typehints) extension infers the types from the function signature so we can remove a little duplication.

Not very important to do this but it was quick and easy to do.

Also cleaned up [this docs page](https://tket.quantinuum.com/extensions/pytket-qiskit/) a bit. Making more use of sphinx crossreferencing.

# Related issues

closes #347

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
