### PR TITLE
Remove some deprecation warnings

### DIFF
--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -43,7 +43,8 @@ from qiskit_ibm_runtime import (  # type: ignore
     SamplerV2,
     RuntimeJob,
 )
-from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
+from qiskit_ibm_runtime.models.backend_configuration import PulseBackendConfiguration  # type: ignore
+from qiskit_ibm_runtime.models.backend_properties import BackendProperties  # type: ignore
 
 from pytket.circuit import Bit, Circuit, OpType
 from pytket.backends import Backend, CircuitNotRunError, CircuitStatus, ResultHandle
@@ -91,7 +92,7 @@ from ..qiskit_convert import (
 from .._metadata import __extension_version__
 
 if TYPE_CHECKING:
-    from qiskit.providers.backend import BackendV1  # type: ignore
+    from qiskit_ibm_runtime.ibm_backend import IBMBackend  # type: ignore
 
 _DEBUG_HANDLE_PREFIX = "_MACHINE_DEBUG_"
 
@@ -182,8 +183,8 @@ class IBMQBackend(Backend):
             if service is None
             else service
         )
-        self._backend: "BackendV1" = self._service.backend(backend_name)
-        config: QasmBackendConfiguration = self._backend.configuration()
+        self._backend: "IBMBackend" = self._service.backend(backend_name)
+        config: PulseBackendConfiguration = self._backend.configuration()
         self._max_per_job = getattr(config, "max_experiments", 1)
 
         gate_set = _tk_gate_set(config)
@@ -228,7 +229,7 @@ class IBMQBackend(Backend):
     @classmethod
     def _get_backend_info(
         cls,
-        config: QasmBackendConfiguration,
+        config: PulseBackendConfiguration,
         props: Optional[BackendProperties],
     ) -> BackendInfo:
         """Construct a BackendInfo from data returned by the IBMQ API.
@@ -372,7 +373,7 @@ class IBMQBackend(Backend):
           the default settings in :py:class:`NoiseAwarePlacement`.
         :return: Compilation pass guaranteeing required predicates.
         """
-        config: QasmBackendConfiguration = self._backend.configuration()
+        config: PulseBackendConfiguration = self._backend.configuration()
         props: Optional[BackendProperties] = self._backend.properties()
         return IBMQBackend.default_compilation_pass_offline(
             config, props, optimisation_level, placement_options
@@ -380,7 +381,7 @@ class IBMQBackend(Backend):
 
     @staticmethod
     def default_compilation_pass_offline(
-        config: QasmBackendConfiguration,
+        config: PulseBackendConfiguration,
         props: Optional[BackendProperties],
         optimisation_level: int = 2,
         placement_options: Optional[dict[str, Any]] = None,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -60,7 +60,8 @@ from qiskit.circuit.library import (
     UnitaryGate,
     Initialize,
 )
-from qiskit.providers.models import BackendProperties, QasmBackendConfiguration  # type: ignore
+from qiskit_ibm_runtime.models.backend_configuration import PulseBackendConfiguration  # type: ignore
+from qiskit_ibm_runtime.models.backend_properties import BackendProperties  # type: ignore
 
 from pytket.circuit import (
     CircBox,
@@ -84,8 +85,8 @@ from pytket.utils import QubitPauliOperator, gen_term_sequence_circuit
 from pytket.passes import RebaseCustom
 
 if TYPE_CHECKING:
-    from qiskit.providers.backend import BackendV1  # type: ignore
-    from qiskit.providers.models.backendproperties import Nduv  # type: ignore
+    from qiskit_ibm_runtime.ibm_backend import IBMBackend  # type: ignore
+    from qiskit_ibm_runtime.models.backend_properties import Nduv
     from qiskit.circuit.quantumcircuitdata import QuantumCircuitData  # type: ignore
     from pytket.circuit import Op, UnitID
 
@@ -204,7 +205,7 @@ _gate_str_2_optype_rev = {v: k for k, v in _gate_str_2_optype.items()}
 _gate_str_2_optype_rev[OpType.Unitary1qBox] = "unitary"
 
 
-def _tk_gate_set(config: QasmBackendConfiguration) -> set[OpType]:
+def _tk_gate_set(config: PulseBackendConfiguration) -> set[OpType]:
     """Set of tket gate types supported by the qiskit backend"""
     if config.simulator:
         gate_set = {
@@ -863,9 +864,9 @@ def tk_to_qiskit(
     return qcirc
 
 
-def process_characterisation(backend: "BackendV1") -> dict[str, Any]:
-    """Convert a :py:class:`qiskit.providers.backend.BackendV1` to a dictionary
-     containing device Characteristics
+def process_characterisation(backend: "IBMBackend") -> dict[str, Any]:
+    """Convert a :py:class:`qiskit_ibm_runtime.ibm_backend.IBMBackend` to a
+    dictionary containing device Characteristics
 
     :param backend: A backend to be converted
     :return: A dictionary containing device characteristics
@@ -876,7 +877,7 @@ def process_characterisation(backend: "BackendV1") -> dict[str, Any]:
 
 
 def process_characterisation_from_config(
-    config: QasmBackendConfiguration, properties: Optional[BackendProperties]
+    config: PulseBackendConfiguration, properties: Optional[BackendProperties]
 ) -> dict[str, Any]:
     """Obtain a dictionary containing device Characteristics given config and props.
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     install_requires=[
         "pytket >= 1.30.0",
         "qiskit >= 1.2.0",
-        "qiskit-algorithms >= 0.3.0",
         "qiskit-ibm-runtime >= 0.24.1",
         "qiskit-aer >= 0.14.2",
         "numpy >= 1.26.4",

--- a/tests/qiskit_backend_test.py
+++ b/tests/qiskit_backend_test.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 
 import os
-from typing import Any
 
 import numpy as np
 import pytest
 
 from qiskit import QuantumCircuit  # type: ignore
-from qiskit.primitives import BackendSampler  # type: ignore
+from qiskit.primitives import BackendSamplerV2  # type: ignore
 from qiskit.providers import JobStatus  # type: ignore
-from qiskit_algorithms import Grover, AmplificationProblem, AlgorithmError  # type: ignore
 from qiskit_aer import Aer  # type: ignore
 
 from pytket.extensions.qiskit import (
@@ -31,7 +29,6 @@ from pytket.extensions.qiskit import (
     IBMQEmulatorBackend,
 )
 from pytket.extensions.qiskit.tket_backend import TketBackend
-from pytket.circuit import OpType
 from pytket.architecture import Architecture, FullyConnected
 
 from .mock_pytket_backend import MockShotBackend
@@ -110,8 +107,8 @@ def test_qiskit_counts(brisbane_emulator_backend: IBMQEmulatorBackend) -> None:
     qc.cx(0, 1)
     qc.measure_all()
 
-    s = BackendSampler(
-        TketBackend(
+    s = BackendSamplerV2(
+        backend=TketBackend(
             brisbane_emulator_backend,
             comp_pass=brisbane_emulator_backend.default_compilation_pass(
                 optimisation_level=0
@@ -122,8 +119,8 @@ def test_qiskit_counts(brisbane_emulator_backend: IBMQEmulatorBackend) -> None:
     job = s.run([qc], shots=10)
     res = job.result()
 
-    assert res.metadata[0]["shots"] == 10
-    assert all(n in range(4) for n in res.quasi_dists[0].keys())
+    assert res[0].metadata["shots"] == 10
+    assert all(n in range(4) for n in res[0].data["meas"].get_int_counts())
 
 
 def test_architectures() -> None:
@@ -139,51 +136,3 @@ def test_architectures() -> None:
         assert all(((r[0] == "1" and r[1] == r[2]) for r in shots))
         counts = job.result().get_counts()
         assert all(((r[0] == "1" and r[1] == r[2]) for r in counts.keys()))
-
-
-def test_grover() -> None:
-    # https://github.com/CQCL/pytket-qiskit/issues/15
-    b = MockShotBackend()
-    backend = TketBackend(b, b.default_compilation_pass())
-    sampler = BackendSampler(backend)
-    oracle = QuantumCircuit(2)
-    oracle.cz(0, 1)
-
-    def is_good_state(bitstr: Any) -> bool:
-        return sum(map(int, bitstr)) == 2
-
-    problem = AmplificationProblem(oracle=oracle, is_good_state=is_good_state)
-    grover = Grover(sampler=sampler)
-    result = grover.amplify(problem)
-    assert result.top_measurement == "11"
-
-
-def test_unsupported_gateset() -> None:
-    # Working with gatesets that are unsupported by qiskit requires
-    # providing a custom pass manager.
-    b = MockShotBackend(gate_set={OpType.Rz, OpType.PhasedX, OpType.ZZMax})
-    backend = TketBackend(b, b.default_compilation_pass())
-    sampler = BackendSampler(backend)
-    oracle = QuantumCircuit(2)
-    oracle.cz(0, 1)
-
-    def is_good_state(bitstr: Any) -> bool:
-        return sum(map(int, bitstr)) == 2
-
-    problem = AmplificationProblem(oracle=oracle, is_good_state=is_good_state)
-    grover = Grover(sampler=sampler)
-    # Qiskit will attempt to rebase a Grover op into the MockShotBackend gateset.
-    # However, Rz, PhasedX and ZZMax gateset isn't supported by qiskit.
-    # (tested with qiskit 0.44.1)
-    with pytest.raises(AlgorithmError) as e:
-        result = grover.amplify(problem)
-    err_msg = "Unable to translate"
-    assert err_msg in str(e.getrepr())
-
-    # By skipping transpilation we can rely on the backend's default compilation pass to
-    # rebase.
-    sampler = BackendSampler(backend, skip_transpilation=True)
-    grover = Grover(sampler=sampler)
-    problem = AmplificationProblem(oracle=oracle, is_good_state=is_good_state)
-    result = grover.amplify(problem)
-    assert result.top_measurement == "11"

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -2,5 +2,4 @@ pytest
 pytest-timeout
 pytest-rerunfailures
 hypothesis
-qiskit-algorithms
 requests_mock

--- a/tests/test-requirements.txt
+++ b/tests/test-requirements.txt
@@ -2,4 +2,5 @@ pytest
 pytest-timeout
 pytest-rerunfailures
 hypothesis
+qiskit-algorithms
 requests_mock


### PR DESCRIPTION
Another step towards #350 ...

I think the only deprecation warnings now are from `TketBackend`, which is not so easy to update and may require a complete rewrite ...

I deleted a couple of tests that use `qiskit_algorithms` which depended on the deprecated classes. There is a similar example in the user manual. I've checked that it still works.