### PR TITLE
Use `AutoRebase` in `tk_to_qiskit` rather than `RebaseCustom`

### DIFF
--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -82,7 +82,7 @@ from pytket.unit_id import _TEMP_BIT_NAME
 from pytket.pauli import Pauli, QubitPauliString
 from pytket.architecture import Architecture, FullyConnected
 from pytket.utils import QubitPauliOperator, gen_term_sequence_circuit
-from pytket.passes import RebaseCustom
+from pytket.passes import AutoRebase
 
 if TYPE_CHECKING:
     from qiskit_ibm_runtime.ibm_backend import IBMBackend  # type: ignore
@@ -762,9 +762,6 @@ order or only one bit of one register"""
     return qcirc.append(g, qargs=qargs)
 
 
-# Define varibles for RebaseCustom
-_cx_replacement = Circuit(2).CX(0, 1)
-
 # The set of tket gates that can be converted directly to qiskit gates
 _supported_tket_gates = set(_known_gate_rev_phase.keys())
 
@@ -779,18 +776,8 @@ _protected_tket_gates = (
 )
 
 
-Param = Union[float, "sympy.Expr"]  # Type for TK1 and U3 parameters
-
-
-# Use the U3 gate for tk1_replacement as this is a member of _supported_tket_gates
-def _tk1_to_u3(a: Param, b: Param, c: Param) -> Circuit:
-    tk1_circ = Circuit(1)
-    tk1_circ.add_gate(OpType.U3, [b, a - 1 / 2, c + 1 / 2], [0]).add_phase(-(a + c) / 2)
-    return tk1_circ
-
-
 # This is a rebase to the set of tket gates which have an exact substitution in qiskit
-supported_gate_rebase = RebaseCustom(_protected_tket_gates, _cx_replacement, _tk1_to_u3)
+supported_gate_rebase = AutoRebase(_protected_tket_gates)
 
 
 def tk_to_qiskit(

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -19,7 +19,6 @@ from collections import defaultdict
 from typing import (
     Callable,
     Optional,
-    Union,
     Any,
     Iterable,
     cast,


### PR DESCRIPTION
# Description

Replaces the rebase pass in the `tk_to_qiskit` conversion with `AutoRebase`. It doesn't require a `tk1_replacement` function and so it better from the point of view of serialization. Its also a bit cleaner syntatically and allows us to delete some unecessary lines which define variables for `RebaseCustom`.

This PR supercedes #386 as I don't see a reason for this to wait until the refactor of `tk_to_qiskit` and `qiskit_to_tk` is done.

As mentioned in the related issue, I'm a little puzzled that this shows up in the dict of the `default_compilation_pass` for IBM backends. I think it would be worth checking to see if the passes are serilaized correctly.

# Related issues
#361

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
