### PR TITLE
Initialize `TketAutoPass` with a `BackendV2`

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Unreleased
 * Fix conversion of symbols into qiskit.
 * Require qiskit >= 1.2.0.
 * Add conversion of controlled unitary gates from qiskit to tket.
+* Initialize `TketAutoPass` with a `BackendV2`.
 
 0.55.0 (July 2024)
 ------------------

--- a/pytket/extensions/qiskit/tket_pass.py
+++ b/pytket/extensions/qiskit/tket_pass.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 from qiskit.dagcircuit import DAGCircuit  # type: ignore
-from qiskit.providers import BackendV1  # type: ignore
+from qiskit.providers import BackendV2  # type: ignore
 from qiskit.transpiler.basepasses import TransformationPass, BasePass as qBasePass  # type: ignore
 from qiskit.converters import circuit_to_dag, dag_to_circuit  # type: ignore
 from qiskit_aer.backends import AerSimulator  # type: ignore
@@ -76,7 +76,7 @@ class TketAutoPass(TketPass):
 
     def __init__(
         self,
-        backend: BackendV1,
+        backend: BackendV2,
         optimisation_level: int = 2,
         token: Optional[str] = None,
     ):


### PR DESCRIPTION
Last of the low-hanging fruit? Just `TketBackend` to go.