### PR TITLE
feat: Improved handling of controlled gates in converters

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,6 +31,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
+        submodules: true
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'
@@ -73,15 +74,17 @@ jobs:
       with:
         name: artefact-${{ matrix.os }}
         path: wheelhouse/
+    - name: Install poetry
+      run: pip install poetry
     - name: Install docs dependencies
       if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       run: |
-        pip install -r .github/workflows/docs/requirements.txt
+        cd docs && poetry install
     - name: Build docs
       if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20
       run: |
-        ./.github/workflows/docs/check-build-docs
+        cd docs && poetry run bash ./build-docs.sh
 
 
   publish_to_pypi:
@@ -128,14 +131,18 @@ jobs:
         path: wheelhouse
     - name: Install pip, wheel
       run: pip install -U pip wheel
+    - name: Install poetry
+      run: pip install poetry
     - name: Install extension
       run: for w in `find wheelhouse/ -type f -name "*.whl"` ; do pip install $w ; done
     - name: Install docs dependencies
       run: |
-        pip install -r .github/workflows/docs/requirements.txt
+        cd docs
+        poetry install
     - name: Build docs
       timeout-minutes: 20
       run: |
-        cd .github/workflows/docs
-        mkdir extensions
-        ./build-docs -d ${GITHUB_WORKSPACE}/.github/workflows/docs/extensions/api
+        cd docs
+        poetry run bash ./build-docs.sh
+
+

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'
@@ -74,17 +73,15 @@ jobs:
       with:
         name: artefact-${{ matrix.os }}
         path: wheelhouse/
-    - name: Install poetry
-      run: pip install poetry
     - name: Install docs dependencies
       if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       run: |
-        cd docs && poetry install
+        pip install -r .github/workflows/docs/requirements.txt
     - name: Build docs
       if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20
       run: |
-        cd docs && poetry run bash ./build-docs.sh
+        ./.github/workflows/docs/check-build-docs
 
 
   publish_to_pypi:
@@ -131,18 +128,14 @@ jobs:
         path: wheelhouse
     - name: Install pip, wheel
       run: pip install -U pip wheel
-    - name: Install poetry
-      run: pip install poetry
     - name: Install extension
       run: for w in `find wheelhouse/ -type f -name "*.whl"` ; do pip install $w ; done
     - name: Install docs dependencies
       run: |
-        cd docs
-        poetry install
+        pip install -r .github/workflows/docs/requirements.txt
     - name: Build docs
       timeout-minutes: 20
       run: |
-        cd docs
-        poetry run bash ./build-docs.sh
-
-
+        cd .github/workflows/docs
+        mkdir extensions
+        ./build-docs -d ${GITHUB_WORKSPACE}/.github/workflows/docs/extensions/api

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,7 +6,7 @@ Changelog
 Unreleased
 ----------
 * Added handling of generalised controlled gates to :py:func:`qiskit_to_tk` and :py:func:`tk_to_qiskit`. The `control_state` is handled directly instead of using additional `X` gates.
-
+* A controlled :py:class:`UnitaryGate` will now be converted to a pytket controlled unitary box by :py:func:`qiskit_to_tk` instead of a controlled :py:class:`~pytket.circuit.CircBox` with a unitary box inside.
 
 0.56.0 (September 2024)
 -----------------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,10 @@ Changelog
 
 .. currentmodule:: pytket.extensions.qiskit
 
+Unreleased
+----------
+* Added handling of generalised controlled gates to :py:func:`qiskit_to_tk` and :py:func:`tk_to_qiskit`. The `control_state` is handled directly instead of using additional `X` gates.
+
 
 0.56.0 (September 2024)
 -----------------------

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -538,8 +538,6 @@ class CircuitBuilder:
 
             elif type(instr) is UnitaryGate:
                 unitary = cast(NDArray[np.complex128], instr.params[0])
-                dim: int = 2**instr.num_qubits
-                assert unitary.shape == (dim, dim)
                 if len(qubits) == 0:
                     # If the UnitaryGate acts on no qubits, we add a phase.
                     self.tkc.add_phase(np.angle(unitary[0][0]) / np.pi)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -586,40 +586,6 @@ class CircuitBuilder:
                 self.tkc.add_gate(optype, params, qubits + bits, **condition_kwargs)  # type: ignore
 
 
-def add_qiskit_unitary_to_tkc(
-    tkc: Circuit,
-    u_gate: UnitaryGate,
-    qubits: list[Qubit],
-    condition_kwargs: dict[str, Any],
-) -> None:
-    # Note reversal of qubits, to account for endianness (pytket unitaries
-    # are ILO-BE == DLO-LE; qiskit unitaries are ILO-LE == DLO-BE).
-    params = u_gate.params
-    assert len(params) == 1
-    u = cast(np.ndarray, params[0])
-
-    n = len(qubits)
-    if n == 0:
-        assert u.shape == (1, 1)
-        tkc.add_phase(np.angle(u[0][0]) / np.pi)
-    elif n == 1:
-        assert u.shape == (2, 2)
-        u1box = Unitary1qBox(u)
-        tkc.add_unitary1qbox(u1box, qubits[0], **condition_kwargs)
-    elif n == 2:
-        assert u.shape == (4, 4)
-        u2box = Unitary2qBox(u)
-        tkc.add_unitary2qbox(u2box, qubits[1], qubits[0], **condition_kwargs)
-    elif n == 3:
-        assert u.shape == (8, 8)
-        u3box = Unitary3qBox(u)
-        tkc.add_unitary3qbox(u3box, qubits[2], qubits[1], qubits[0], **condition_kwargs)
-    else:
-        raise NotImplementedError(
-            f"Conversion of {n}-qubit unitary gates not supported."
-        )
-
-
 def qiskit_to_tk(qcirc: QuantumCircuit, preserve_param_uuid: bool = False) -> Circuit:
     """
     Converts a qiskit :py:class:`qiskit.QuantumCircuit` to a pytket :py:class:`Circuit`.

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -290,6 +290,12 @@ def _string_to_circuit(
     return circ
 
 
+def _to_big_endian(string: str) -> tuple[bool, ...]:
+    "Converts a little endian string '001'=1 (LE) to (1, 0, 0)."
+    assert set(string) == {"0", "1"}
+    return tuple(bool(int(b)) for b in string[::-1])
+
+
 def _get_controlled_tket_optype(c_gate: ControlledGate) -> OpType:
     """Get a pytket contolled OpType from a qiskit ControlledGate."""
     if c_gate.base_class in _known_qiskit_gate:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -709,7 +709,8 @@ def append_tk_command_to_qiskit(
             base_qiskit_gate, phase = _known_gate_rev_phase[op.get_op().type]
         except KeyError:
             raise NotImplementedError(
-                f"Conversion of QControlBox with base gate {op.get_op()} not supported by tk_to_qiskit."
+                "Conversion of QControlBox with base gate"
+                + f"{op.get_op()} not supported by tk_to_qiskit."
             )
 
         qiskit_controlled_gate: ControlledGate = base_qiskit_gate().control(

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -293,7 +293,7 @@ def _string_to_circuit(
 def _get_pytket_ctrl_state(bitstring: str, n_bits: int) -> tuple[bool, ...]:
     "Converts a little endian string '001'=1 (LE) to (1, 0, 0)."
     assert set(bitstring).issubset({"0", "1"})
-    pytket_ctrl_state = list(bool(int(b)) for b in bitstring[::-1])
+    pytket_ctrl_state = [bool(int(b)) for b in bitstring[::-1]]
     padding_zeros: list[bool] = [False] * (n_bits - len(bitstring))
     pytket_ctrl_state.extend(padding_zeros)
     return tuple(pytket_ctrl_state)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -538,7 +538,10 @@ class CircuitBuilder:
 
             elif type(instr) is UnitaryGate:
                 unitary = cast(NDArray[np.complex128], instr.params[0])
+                dim: int = 2**instr.num_qubits
+                assert unitary.shape == (dim, dim)
                 if len(qubits) == 0:
+                    # If the UnitaryGate acts on no qubits, we add a phase.
                     self.tkc.add_phase(np.angle(unitary[0][0]) / np.pi)
                 else:
                     unitary_box = _get_unitary_box(unitary=unitary)

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -378,17 +378,17 @@ def _get_unitary_box(u_gate: UnitaryGate) -> UnitaryBox:
 
 
 def _get_qcontrol_box(c_gate: ControlledGate, params: list[float]) -> QControlBox:
-    if type(c_gate.base_gate) is UnitaryGate:
+    qiskit_ctrl_state: str = bin(c_gate.ctrl_state)[2:]
+    pytket_ctrl_state: tuple[bool, ...] = _get_pytket_ctrl_state(
+        bitstring=qiskit_ctrl_state, n_bits=c_gate.num_ctrl_qubits
+    )
+    if isinstance(c_gate.base_gate, UnitaryGate):
         base_op: Op = _get_unitary_box(c_gate.base_gate)
     else:
         base_tket_gate: OpType = _known_qiskit_gate[c_gate.base_gate.base_class]
 
         base_op: Op = Op.create(base_tket_gate, params)
 
-    qiskit_ctrl_state: str = bin(c_gate.ctrl_state)[2:]
-    pytket_ctrl_state: tuple[bool, ...] = _get_pytket_ctrl_state(
-        bitstring=qiskit_ctrl_state, n_bits=c_gate.num_ctrl_qubits
-    )
     return QControlBox(
         base_op, n_controls=c_gate.num_ctrl_qubits, control_state=pytket_ctrl_state
     )

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -383,6 +383,7 @@ def _get_qcontrol_box(c_gate: ControlledGate, params: list[float]) -> QControlBo
     )
     if isinstance(c_gate.base_gate, UnitaryGate):
         unitary = c_gate.base_gate.params[0]
+        # Here we reverse the order of the columns to correct for endianness.
         new_unitary: NDArray[np.complex128] = permute_rows_cols_in_unitary(
             matrix=unitary,
             permutation=tuple(reversed(range(c_gate.base_gate.num_qubits))),

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -495,11 +495,7 @@ class CircuitBuilder:
                     )
                 c_box = CircBox(sub_circ)
 
-                if instr.ctrl_state is not None:
-                    qiskit_ctrl_state: str = bin(instr.ctrl_state)[2:]
-                else:
-                    qiskit_ctrl_state = "1" * instr.num_ctrl_qubits
-
+                qiskit_ctrl_state: str = bin(instr.ctrl_state)[2:]
                 pytket_ctrl_state = _get_pytket_ctrl_state(
                     qiskit_ctrl_state, n_bits=instr.num_ctrl_qubits
                 )

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -387,8 +387,9 @@ def _get_qcontrol_box(c_gate: ControlledGate, params: list[float]) -> QControlBo
     )
     if isinstance(c_gate.base_gate, UnitaryGate):
         unitary = c_gate.base_gate.params[0]
-        new_unitary = permute_rows_cols_in_unitary(
-            unitary, tuple(reversed(range(c_gate.base_gate.num_qubits)))
+        new_unitary: NDArray[np.complex128] = permute_rows_cols_in_unitary(
+            matrix=unitary,
+            permutation=tuple(reversed(range(c_gate.base_gate.num_qubits))),
         )
         u_gate = UnitaryGate(new_unitary)
         base_op: Op = _get_unitary_box(u_gate)
@@ -540,8 +541,9 @@ class CircuitBuilder:
                 self.tkc.add_circbox(ccbox, qubits)
 
             elif type(instr) is UnitaryGate:
-                if instr.num_qubits == 0:
-                    add_qiskit_unitary_to_tkc(self.tkc, instr, qubits, condition_kwargs)
+                unitary = instr.params[0]
+                if len(qubits) == 0:
+                    self.tkc.add_phase(np.angle(unitary[0][0]) / np.pi)
                 else:
                     unitary_box = _get_unitary_box(instr)
                     self.tkc.add_gate(

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -388,7 +388,7 @@ def _get_qcontrol_box(c_gate: ControlledGate, params: list[float]) -> QControlBo
             matrix=unitary,
             permutation=tuple(reversed(range(c_gate.base_gate.num_qubits))),
         )
-        base_op: Op = _get_unitary_box(new_unitary)  # type: ignore
+        base_op: Op = _get_unitary_box(new_unitary)
     else:
         base_tket_gate: OpType = _known_qiskit_gate[c_gate.base_gate.base_class]
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -24,7 +24,6 @@ from typing import (
     cast,
     TypeVar,
     TYPE_CHECKING,
-    Union,
 )
 from inspect import signature
 from uuid import UUID
@@ -357,7 +356,7 @@ def _optype_from_qiskit_instruction(instruction: Instruction) -> OpType:
         )
 
 
-UnitaryBox = Union[Unitary1qBox, Unitary2qBox, Unitary3qBox]
+UnitaryBox = Unitary1qBox | Unitary2qBox | Unitary3qBox
 
 
 def _get_unitary_box(u_gate: UnitaryGate) -> UnitaryBox:

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -388,11 +388,11 @@ def _get_qcontrol_box(c_gate: ControlledGate, params: list[float]) -> QControlBo
             matrix=unitary,
             permutation=tuple(reversed(range(c_gate.base_gate.num_qubits))),
         )
-        base_op: Op = _get_unitary_box(new_unitary)
+        base_op: Op = _get_unitary_box(new_unitary)  # type: ignore
     else:
         base_tket_gate: OpType = _known_qiskit_gate[c_gate.base_gate.base_class]
 
-        base_op: Op = Op.create(base_tket_gate, params)
+        base_op: Op = Op.create(base_tket_gate, params)  # type: ignore
 
     return QControlBox(
         base_op, n_controls=c_gate.num_ctrl_qubits, control_state=pytket_ctrl_state

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -297,9 +297,8 @@ def _string_to_circuit(
 def _get_pytket_ctrl_state(bitstring: str, n_bits: int) -> tuple[bool, ...]:
     "Converts a little endian string '001'=1 (LE) to (1, 0, 0)."
     assert set(bitstring).issubset({"0", "1"})
-    pytket_ctrl_state = [bool(int(b)) for b in bitstring[::-1]]
-    padding_zeros: list[bool] = [False] * (n_bits - len(bitstring))
-    pytket_ctrl_state.extend(padding_zeros)
+    padded_bitstring = bitstring.zfill(n_bits)
+    pytket_ctrl_state = reversed([bool(int(b)) for b in padded_bitstring])
     return tuple(pytket_ctrl_state)
 
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -24,7 +24,6 @@ from typing import (
     cast,
     TypeVar,
     TYPE_CHECKING,
-    Type,
 )
 from inspect import signature
 from uuid import UUID

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -496,8 +496,8 @@ class CircuitBuilder:
                 c_box = CircBox(sub_circ)
 
                 qiskit_ctrl_state: str = bin(instr.ctrl_state)[2:]
-                pytket_ctrl_state = _get_pytket_ctrl_state(
-                    qiskit_ctrl_state, n_bits=instr.num_ctrl_qubits
+                pytket_ctrl_state: tuple[bool, ...] = _get_pytket_ctrl_state(
+                    bitstring=qiskit_ctrl_state, n_bits=instr.num_ctrl_qubits
                 )
                 q_ctrl_box = QControlBox(
                     c_box,
@@ -664,6 +664,9 @@ def append_tk_command_to_qiskit(
     if optype == OpType.Reset:
         qb = qregmap[args[0].reg_name][args[0].index[0]]
         return qcirc.reset(qb)
+    
+    if optype == OpType.QControlBox:
+
 
     if optype in [OpType.CircBox, OpType.ExpBox, OpType.PauliExpBox, OpType.CustomGate]:
         subcircuit = op.get_circuit()  # type: ignore

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -44,11 +44,13 @@ from pytket.circuit import (
     Unitary2qBox,
     Unitary3qBox,
     OpType,
+    Op,
     Qubit,
     Bit,
     CustomGateDef,
     reg_eq,
     StatePreparationBox,
+    QControlBox,
 )
 from pytket.extensions.qiskit import tk_to_qiskit, qiskit_to_tk, IBMQBackend
 from pytket.extensions.qiskit.backends import qiskit_aer_backend
@@ -863,6 +865,20 @@ def test_controlled_unitary_conversion() -> None:
     tkc = qiskit_to_tk(qc)
     u_tkc = tkc.get_unitary()
     assert np.allclose(u_qc, u_tkc)
+
+
+def test_qcontrol_box_conversion_to_qiskit() -> None:
+    h_op = Op.create(OpType.H)
+    multi_controlled_h = QControlBox(
+        h_op, n_controls=3, control_state=(False, False, True)
+    )
+    circ = Circuit(4, name="CCH test")
+    circ.add_gate(multi_controlled_h, [0, 1, 2, 3])
+    qc = tk_to_qiskit(circ)
+    circ2 = qiskit_to_tk(qc)
+    DecomposeBoxes().apply(circ)
+    DecomposeBoxes().apply(circ2)
+    assert circ == circ2
 
 
 # Ensures that the tk_to_qiskit converter does not cancel redundant gates

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -872,13 +872,14 @@ def test_qcontrol_box_conversion_to_qiskit() -> None:
     multi_controlled_h = QControlBox(
         h_op, n_controls=3, control_state=(False, False, True)
     )
-    circ = Circuit(4, name="CCH test")
-    circ.add_gate(multi_controlled_h, [0, 1, 2, 3])
-    qc = tk_to_qiskit(circ)
+    circ1 = Circuit(4, name="CCH test")
+    circ1.add_gate(multi_controlled_h, [0, 1, 2, 3])
+    qc = tk_to_qiskit(circ1)
     circ2 = qiskit_to_tk(qc)
-    DecomposeBoxes().apply(circ)
+    DecomposeBoxes().apply(circ1)
     DecomposeBoxes().apply(circ2)
-    assert circ == circ2
+    assert circ1 == circ2
+    assert compare_unitaries(circ1.get_unitary(), circ2.get_unitary())
 
 
 # Ensures that the tk_to_qiskit converter does not cancel redundant gates

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -886,11 +886,12 @@ def test_qcontrol_box_conversion_to_qiskit() -> None:
     circ1.add_gate(cccRy_100, [3, 2, 1, 0])
     circ1.add_gate(ccU3_10, [1, 0, 2])
     qc = tk_to_qiskit(circ1)
+    qiskit_unitary = permute_rows_cols_in_unitary(Operator(qc).data, (3, 2, 1, 0))
+    assert compare_unitaries(qiskit_unitary, circ1.get_unitary())
     circ2 = qiskit_to_tk(qc)
     DecomposeBoxes().apply(circ1)
     DecomposeBoxes().apply(circ2)
     assert circ1 == circ2
-    assert compare_unitaries(circ1.get_unitary(), circ2.get_unitary())
 
 
 # Ensures that the tk_to_qiskit converter does not cancel redundant gates

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -868,12 +868,23 @@ def test_controlled_unitary_conversion() -> None:
 
 
 def test_qcontrol_box_conversion_to_qiskit() -> None:
-    h_op = Op.create(OpType.H)
-    multi_controlled_h = QControlBox(
-        h_op, n_controls=3, control_state=(False, False, True)
+    ccch_001 = QControlBox(
+        Op.create(OpType.H), n_controls=3, control_state=(False, False, True)
     )
-    circ1 = Circuit(4, name="CCH test")
-    circ1.add_gate(multi_controlled_h, [0, 1, 2, 3])
+    cccs_110 = QControlBox(
+        Op.create(OpType.S), n_controls=3, control_state=(True, True, False)
+    )
+    cccRy_100 = QControlBox(
+        Op.create(OpType.Ry, 0.73), n_controls=3, control_state=(True, False, False)
+    )
+    ccU3_10 = QControlBox(
+        Op.create(OpType.U3, [0.1, 0.2, 0.3]), n_controls=2, control_state=(True, False)
+    )
+    circ1 = Circuit(4, name="test_circ")
+    circ1.add_gate(ccch_001, [0, 1, 2, 3])
+    circ1.add_gate(cccs_110, [0, 1, 2, 3])
+    circ1.add_gate(cccRy_100, [3, 2, 1, 0])
+    circ1.add_gate(ccU3_10, [1, 0, 2])
     qc = tk_to_qiskit(circ1)
     circ2 = qiskit_to_tk(qc)
     DecomposeBoxes().apply(circ1)


### PR DESCRIPTION
# Description

This PR adds support for handling the `control_state` of a controlled operation in the `qiskit_to_tk` and `tk_to_qiskit` converters. The control state is now handled directly instead of adding `X` gates on the control qubits.

I've also taken the liberty of refactoring out the "`QControlBox` building" from the `CircuitBuildier.add_qiskit_data` method in the same spirit as  #382 

I've also reworked some internals of how unitary gates are converted to and fro. Handling of controlled unitary boxes was added in #372 . ~I think it'd be fairly easy to add the other direction into this PR too (see #378)~ (I think its best to do this separately).

Original PR adding control state handling with X gates -> https://github.com/CQCL/pytket-qiskit/pull/118

# Related issues
#378 
#313 
closes #178 



# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
