### PR TITLE
docs: fix autosummary table alignment on docs page

### DIFF
--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -218,27 +218,14 @@ Using TKET directly on qiskit circuits
 
 For usage of :py:class:`~pytket.extensions.qiskit.TketBackend` see the `qiskit integration notebook example <https://tket.quantinuum.com/examples/qiskit_integration.html>`_.
 
-.. currentmodule:: pytket.extensions.qiskit.tket_backend
-
 .. autosummary::
     :nosignatures:
 
-    TketBackend
+    ~tket_backend.TketBackend
+    ~tket_pass.TketPass
+    ~tket_pass.TketAutoPass
+    ~tket_job.TketJob
 
-.. currentmodule:: pytket.extensions.qiskit.tket_pass
-
-.. autosummary::
-    :nosignatures:
-
-    TketPass
-    TketAutoPass
-
-.. currentmodule:: pytket.extensions.qiskit.tket_job
-
-.. autosummary::
-    :nosignatures:
-
-    TketJob
 
 
 .. toctree::

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -215,8 +215,11 @@ Noise Modelling
 
 Using TKET directly on qiskit circuits
 ======================================
+.. currentmodule:: pytket.extensions.qiskit
 
-For usage of :py:class:`~pytket.extensions.qiskit.tket_backend.TketBackend` see the `qiskit integration notebook example <https://tket.quantinuum.com/examples/qiskit_integration.html>`_.
+For usage of :py:class:`~tket_backend.TketBackend` see the `qiskit integration notebook example <https://tket.quantinuum.com/examples/qiskit_integration.html>`_.
+
+.. currentmodule:: pytket.extensions.qiskit
 
 .. autosummary::
     :nosignatures:

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -219,8 +219,6 @@ Using TKET directly on qiskit circuits
 
 For usage of :py:class:`~tket_backend.TketBackend` see the `qiskit integration notebook example <https://tket.quantinuum.com/examples/qiskit_integration.html>`_.
 
-.. currentmodule:: pytket.extensions.qiskit
-
 .. autosummary::
     :nosignatures:
 

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -104,7 +104,7 @@ To see which devices you can access, use the :py:meth:`IBMQBackend.available_dev
 
     backend = IBMQBackend("ibm_kyiv") # Initialise backend for an IBM device
 
-    backendinfo_list = backend.available_devices(instance=my_instance) 
+    backendinfo_list = backend.available_devices(instance=inst) 
     print([backend.device_name for backend in backendinfo_list])
 
 For more information, see the documentation for `qiskit-ibm-runtime <https://docs.quantum.ibm.com/api/qiskit-ibm-runtime>`_.

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -216,7 +216,7 @@ Noise Modelling
 Using TKET directly on qiskit circuits
 ======================================
 
-For usage of :py:class:`~pytket.extensions.qiskit.TketBackend` see the `qiskit integration notebook example <https://tket.quantinuum.com/examples/qiskit_integration.html>`_.
+For usage of :py:class:`~pytket.extensions.qiskit.tket_backend.TketBackend` see the `qiskit integration notebook example <https://tket.quantinuum.com/examples/qiskit_integration.html>`_.
 
 .. autosummary::
     :nosignatures:


### PR DESCRIPTION
# Description

fixing the alignment of this table for `TketBackend` and related classes.

Before 

![Screenshot 2024-09-17 at 18 44 50](https://github.com/user-attachments/assets/9fa48a6a-d291-4bef-b21f-ca645483eeb9)


After below (Ignore the styling difference. The latter was built locally using the legacy theme. In the website build the new theme will be used. After #392 we will be able to do local builds with the latest version of the theme)

![Screenshot 2024-09-17 at 18 40 28](https://github.com/user-attachments/assets/3997abc0-7ae7-4c52-856c-4585285319ae)

Also fixed an inconsistent variable in [6d231fe](https://github.com/CQCL/pytket-qiskit/pull/393/commits/6d231fe9c60d2e73200d7d29c37e1c5b39730d47)

