### PR TITLE
Update runners used on CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,7 +25,7 @@ jobs:
     name: Qiskit - Build and test module
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'macos-12', 'windows-2022']
+        os: ['ubuntu-24.04', 'macos-14', 'windows-2022']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4
@@ -48,14 +48,14 @@ jobs:
       with:
         python-version: '3.11'
     - name: Build and test including remote checks (3.11) mypy
-      if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
+      if:  (matrix.os == 'ubuntu-24.04') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
       shell: bash
       run: |
         ./.github/workflows/build-test mypy
       env:
         PYTKET_RUN_REMOTE_TESTS: 1
     - name: Build and test (3.11) nomypy
-      if:  (matrix.os != 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
+      if:  (matrix.os != 'macos-14') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
@@ -77,12 +77,12 @@ jobs:
     - name: Install poetry
       run: pip install poetry
     - name: Install docs dependencies
-      if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
+      if:  (matrix.os == 'ubuntu-24.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       run: |
         cd docs && bash ./install.sh
         for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
     - name: Build docs
-      if:  (matrix.os == 'ubuntu-22.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
+      if:  (matrix.os == 'ubuntu-24.04') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20
       run: |
         cd docs && poetry run bash ./build-docs.sh
@@ -92,7 +92,7 @@ jobs:
     name: Publish to pypi
     if: github.event_name == 'release'
     needs: qiskit-checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Download all wheels
       # downloading all three files into the wheelhouse
@@ -117,7 +117,7 @@ jobs:
     name: Build docs
     if: github.event_name == 'release'
     needs: publish_to_pypi
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   docs:
     name: build docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with: 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   lint:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -21,8 +21,6 @@ jobs:
     - name: Install black and pylint
       run: pip install black pylint
     - name: Check files are formatted with black
-      run: |
-        black --check .
+      run: black --check .
     - name: Run pylint
-      run: |        
-        pylint */
+      run: pylint */


### PR DESCRIPTION
The `macos-12` runner is being removed soon; `macos-latest` is currently `macos-14`. Also update to `ubuntu-24.04` a.k.a. `ubuntu-latest` while we're here.

(Will update names of "required checks" after approval.)
