### PR TITLE
Specify what result types we expect in our Qiskit result conversion functions

### DIFF
--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -348,7 +348,14 @@ class _AerBaseBackend(Backend):
                 raise CircuitNotRunError(handle)
 
             res = job.result()
-            backresults = qiskit_result_to_backendresult(res)
+            backresults = qiskit_result_to_backendresult(
+                res,
+                include_shots=self._supports_shots,
+                include_counts=self._supports_counts,
+                include_state=self._supports_state,
+                include_unitary=self._supports_unitary,
+                include_density_matrix=self._supports_density_matrix,
+            )
             for circ_index, backres in enumerate(backresults):
                 self._cache[ResultHandle(jobid, circ_index, qubit_n, ppc)][
                     "result"

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -26,7 +26,7 @@ import numpy as np
 from qiskit.result import Result  # type: ignore
 from qiskit.result.models import ExperimentResult  # type: ignore
 
-from pytket.circuit import Bit, Qubit, UnitID, Circuit
+from pytket.circuit import Bit, Qubit, UnitID
 
 from pytket.backends.backendresult import BackendResult
 from pytket.utils.outcomearray import OutcomeArray

--- a/pytket/extensions/qiskit/result_convert.py
+++ b/pytket/extensions/qiskit/result_convert.py
@@ -83,7 +83,6 @@ def _result_is_empty_shots(result: ExperimentResult) -> bool:
 
 def qiskit_experimentresult_to_backendresult(
     result: ExperimentResult,
-    ppcirc: Optional[Circuit] = None,
 ) -> BackendResult:
     if not result.success:
         raise RuntimeError(result.status)
@@ -140,7 +139,7 @@ def qiskit_experimentresult_to_backendresult(
         state=state,
         unitary=unitary,
         density_matrix=density_matrix,
-        ppcirc=ppcirc,
+        ppcirc=None,
     )
 
 

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -549,12 +549,17 @@ def test_convert_result() -> None:
     qc1.save_state()
     qisk_result = simulator.run(qc1, shots=10).result()
 
-    tk_res = next(qiskit_result_to_backendresult(qisk_result))
+    # exclude counts from result (we don't expect them
+    # for the statevector sim after all)
+    tk_res = next(qiskit_result_to_backendresult(qisk_result, include_counts=False))
 
     state = tk_res.get_state([Qubit("q2", 1), Qubit("q1", 0), Qubit("q2", 0)])
     correct_state = np.zeros(1 << 3, dtype=complex)
     correct_state[6] = 1 + 0j
     assert compare_statevectors(state, correct_state)
+    # also check that we don't return counts in tket result
+    # even if the qiskit result includes them
+    assert tk_res._counts is None
 
     # check measured
     qc.measure(qr1[0], cr[0])


### PR DESCRIPTION
# Description

Adds parameters to `qiskit_result_to_backendresult` / `qiskit_experimentresult_to_backendresult` to specify which type of results we expect to have back.

Previously, circuits with classical bits submitted to AerStateBackend would have a `counts` field in their returned result, because Qiskit reads from the classical register memory. Now we don't set that, because we don't expect counts to be returned from AerStateBackend so we ignore that field.

Also, we weren't ever passing in anything to `ppcirc` in `qiskit_experimentresult_to_backendresult`, so after discussion with @cqc-melf and @cqc-alec  that's been removed as part of this PR.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
