### PR TITLE
Handle bits selection in results for circuits with non-default registers

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@
 Changelog
 ~~~~~~~~~
 
+Unreleased
+----------
+
+* Fix handling of non-default registers when selecting bits in results.
+
 0.58.0 (October 2024)
 ---------------------
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -15,7 +15,7 @@
 import itertools
 import json
 from ast import literal_eval
-from collections import Counter
+from collections import Counter, OrderedDict
 from collections.abc import Sequence
 from time import sleep
 from typing import (
@@ -75,14 +75,17 @@ from pytket.predicates import (
 from pytket.utils import prepare_circuit
 from pytket.utils.outcomearray import OutcomeArray
 from pytket.utils.results import KwargTypes
-from qiskit.primitives import PrimitiveResult, SamplerResult  # type: ignore
+from qiskit.primitives import (  # type: ignore
+    BitArray,
+    DataBin,
+    PrimitiveResult,
+    SamplerPubResult,
+)
 
 # RuntimeJob has no queue_position attribute, which is referenced
 # via job_monitor see-> https://github.com/CQCL/pytket-qiskit/issues/48
 # therefore we can't use job_monitor until fixed
 # from qiskit.tools.monitor import job_monitor  # type: ignore
-from qiskit.result.distributions import QuasiDistribution  # type: ignore
-
 from .._metadata import __extension_version__
 from ..qiskit_convert import (
     _tk_gate_set,
@@ -99,14 +102,10 @@ if TYPE_CHECKING:
 _DEBUG_HANDLE_PREFIX = "_MACHINE_DEBUG_"
 
 
-def _gen_debug_results(n_qubits: int, shots: int, index: int) -> SamplerResult:
-    debug_dist = {n: 0.0 for n in range(pow(2, n_qubits))}
-    debug_dist[0] = 1.0
-    qd = QuasiDistribution(debug_dist)
-    return SamplerResult(
-        quasi_dists=[qd] * (index + 1),
-        metadata=[{"header_metadata": {}, "shots": shots}] * (index + 1),
-    )
+def _gen_debug_results(n_qubits: int, shots: int) -> PrimitiveResult:
+    n_u8s = (n_qubits - 1) // 8 + 1
+    arr = np.array([[0] * n_u8s for _ in range(shots)], dtype=np.uint8)
+    return PrimitiveResult([SamplerPubResult(DataBin(c=BitArray(arr, n_qubits)))])
 
 
 class NoIBMQCredentialsError(Exception):
@@ -205,7 +204,9 @@ class IBMQBackend(Backend):
         self._monitor = monitor
 
         # cache of results keyed by job id and circuit index
-        self._ibm_res_cache: dict[tuple[str, int], Counter] = dict()
+        self._ibm_res_cache: dict[
+            tuple[str, int], tuple[Counter, Optional[list[Bit]]]
+        ] = dict()
 
         if sampler_options is None:
             sampler_options = SamplerOptions()
@@ -521,14 +522,11 @@ class IBMQBackend(Backend):
 
                 qcs, ppcirc_strs = [], []
                 for tkc in batch_chunk:
-                    tkc1 = tkc.copy()
-                    # Flatten bits to default register in lexicographic order:
-                    tkc1.rename_units({bit: Bit(i) for i, bit in enumerate(tkc1.bits)})
                     if postprocess:
-                        c0, ppcirc = prepare_circuit(tkc1, allow_classical=False)
+                        c0, ppcirc = prepare_circuit(tkc, allow_classical=False)
                         ppcirc_rep = ppcirc.to_dict()
                     else:
-                        c0, ppcirc_rep = tkc1, None
+                        c0, ppcirc_rep = tkc, None
                     if simplify_initial:
                         SimplifyInitial(
                             allow_classical=False, create_all_qubits=True
@@ -594,7 +592,7 @@ class IBMQBackend(Backend):
             if self._MACHINE_DEBUG or jobid.startswith(_DEBUG_HANDLE_PREFIX):
                 shots: int
                 shots, _ = literal_eval(jobid[len(_DEBUG_HANDLE_PREFIX) :])
-                res = _gen_debug_results(n_meas, shots, index)
+                res = _gen_debug_results(n_meas, shots)
             else:
                 try:
                     job = self._retrieve_job(jobid)
@@ -612,21 +610,27 @@ class IBMQBackend(Backend):
                         sleep(10)
 
                 res = job.result(timeout=kwargs.get("timeout"))
-            if isinstance(res, SamplerResult):
-                # TODO Is this code still reachable?
-                for circ_index, (r, d) in enumerate(zip(res.quasi_dists, res.metadata)):
-                    self._ibm_res_cache[(jobid, circ_index)] = Counter(
-                        {n: int(0.5 + d["shots"] * p) for n, p in r.items()}
-                    )
-            else:
-                assert isinstance(res, PrimitiveResult)
-                for circ_index, pub_result in enumerate(res._pub_results):
-                    readouts = pub_result.data.c.array
-                    self._ibm_res_cache[(jobid, circ_index)] = Counter(
-                        _int_from_readout(readout) for readout in readouts
-                    )
+            assert isinstance(res, PrimitiveResult)
+            for circ_index, pub_result in enumerate(res._pub_results):
+                data = pub_result.data
+                c_regs = OrderedDict(
+                    (reg_name, data.__getattribute__(reg_name).num_bits)
+                    for reg_name in sorted(data.keys())
+                )
+                readouts = BitArray.concatenate_bits(
+                    [data.__getattribute__(reg_name) for reg_name in c_regs]
+                ).array
+                self._ibm_res_cache[(jobid, circ_index)] = (
+                    Counter(_int_from_readout(readout) for readout in readouts),
+                    list(
+                        itertools.chain.from_iterable(
+                            [Bit(reg_name, i) for i in range(reg_size)]
+                            for reg_name, reg_size in c_regs.items()
+                        )
+                    ),
+                )
 
-        counts = self._ibm_res_cache[cache_key]  # Counter[int]
+        counts, c_bits = self._ibm_res_cache[cache_key]  # Counter[int], list[Bit]
         # Convert to `OutcomeArray`:
         tket_counts: Counter = Counter()
         for outcome_key, sample_count in counts.items():
@@ -637,7 +641,7 @@ class IBMQBackend(Backend):
             )
             tket_counts[array] = sample_count
         # Convert to `BackendResult`:
-        result = BackendResult(counts=tket_counts, ppcirc=ppcirc)
+        result = BackendResult(c_bits=c_bits, counts=tket_counts, ppcirc=ppcirc)
 
         self._cache[handle] = {"result": result}
         return result


### PR DESCRIPTION
Fixes #339 .

Also use `PrimitiveResult` for debug results instead of `SamplerResult`, to match real devices.

Tested locally by running:
```python
from pytket.circuit import Circuit, Qubit, Bit
from pytket.extensions.qiskit import IBMQBackend

b = IBMQBackend("ibm_nazca")
c = Circuit(5)
c.add_c_register("a", 2)
c.add_c_register("b", 2)
c.add_c_register("c", 1)
c.H(0).CX(0, 1).Measure(Qubit(3), Bit("b", 1)).Measure(Qubit(0), Bit("c", 0))
c1 = b.get_compiled_circuit(c, optimisation_level=1)
h = b.process_circuit(c1, n_shots=10)
r = b.get_result(h)
print(r.get_counts(cbits=[Bit("b", 1), Bit("c", 0)]))
```
Output:
```
Counter({(0, 0): 6, (0, 1): 4})
```