### PR TITLE
fix: Warn user about implicit qubit permutations in `tk_to_qiskit`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 ## Unreleased
 
 -  Fix handling of non-default registers when selecting bits in results.
+- The {py:func}`tk_to_qiskit` converter gives a warning if the input {py:class}`~pytket.circuit.Circuit` contains [implicit qubit permutations](https://docs.quantinuum.com/tket/user-guide/manual/manual_circuit.html#implicit-qubit-permutations). 
 
 ## 0.58.0 (October 2024)
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -856,7 +856,7 @@ _protected_tket_gates = (
 supported_gate_rebase = AutoRebase(_protected_tket_gates)
 
 
-def _has_implicit_perumtation(circ: Circuit) -> bool:
+def _has_implicit_permutation(circ: Circuit) -> bool:
     impl_dict: dict[Qubit, Qubit] = circ.implicit_qubit_permutation()
     return tuple(impl_dict.keys()) != tuple(impl_dict.values())
 
@@ -880,7 +880,7 @@ def tk_to_qiskit(
     if replace_implicit_swaps:
         tkc.replace_implicit_wire_swaps()
 
-    if _has_implicit_perumtation(tkcirc) and not replace_implicit_swaps:
+    if _has_implicit_permutation(tkcirc) and not replace_implicit_swaps:
         warnings.warn(
             "The pytket Circuit contains implicit qubit permutations"
             + " which aren't handled by default."

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -15,6 +15,7 @@
 
 """Methods to allow conversion between Qiskit and pytket circuit classes
 """
+import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from inspect import signature
@@ -90,7 +91,6 @@ from qiskit.circuit.library import (
     StatePreparation,
     UnitaryGate,
 )
-import warnings
 
 if TYPE_CHECKING:
     from qiskit_ibm_runtime.ibm_backend import IBMBackend  # type: ignore

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -857,7 +857,7 @@ supported_gate_rebase = AutoRebase(_protected_tket_gates)
 
 
 def _has_implicit_permutation(circ: Circuit) -> bool:
-    return any(q0 != q1 for q0, q1 in circ.implicit_qubit_permuation().items())
+    return any(q0 != q1 for q0, q1 in circ.implicit_qubit_permutation().items())
 
 
 def tk_to_qiskit(

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -857,8 +857,7 @@ supported_gate_rebase = AutoRebase(_protected_tket_gates)
 
 
 def _has_implicit_permutation(circ: Circuit) -> bool:
-    impl_dict: dict[Qubit, Qubit] = circ.implicit_qubit_permutation()
-    return tuple(impl_dict.keys()) != tuple(impl_dict.values())
+    return any(q0 != q1 for q0, q1 in circ.implicit_qubit_permuation().items())
 
 
 def tk_to_qiskit(

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import warnings
 from collections import Counter
 from math import pi
 
@@ -1171,4 +1172,11 @@ def test_nonregister_bits() -> None:
     c = Circuit(1).X(0).measure_all()
     c.rename_units({Bit(0): Bit(1)})
     with pytest.raises(NotImplementedError):
+        tk_to_qiskit(c)
+
+
+def test_implicit_swap_warning() -> None:
+    c = Circuit(2).H(0).SWAP(0, 1)
+    c.replace_SWAPs()
+    with pytest.warns(UserWarning, match="The pytket Circuit contains implicit qubit"):
         tk_to_qiskit(c)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import warnings
 from collections import Counter
 from math import pi
 


### PR DESCRIPTION
# Description

Minor change to `tk_to_qiskit`. The user now gets a warning if the input pytket `Circuit` contains implicit qubit permutations.

closes #411 

# Related issues

#411 

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
