### PR TITLE
Revert warning related to implcit swaps

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@
 
 # Changelog
 
+## 0.60.0 (Unreleased)
+
+- Revert a change made in release v0.59.0 where users are warned about implicit qubit permutations in {py:func}`tk_to_qiskit`. This avoids spamming the user with unhelpful warnings when using pytket-qiskit backends. These backends handle implicit permutations automatically.
+
 ## 0.59.0 (November 2024)
 
 - Updated pytket version requirement to 1.34.0.

--- a/docs/index.md
+++ b/docs/index.md
@@ -230,7 +230,7 @@ Every {py:class}`~pytket.backends.backend.Backend` in pytket has its own {py:met
 - \[2\] {py:class}`~pytket._tket.passes.AutoRebase` is a conversion to the gateset supported by the backend. For IBM quantum devices and emulators the supported gate set is either $\{X, SX, Rz, CX\}$, $\{X, SX, Rz, ECR\}$, or $\{X, SX, Rz, CZ\}$. The more idealised Aer simulators have a much broader range of supported gates.
 - \[3\] This is imported from qiskit and corresponds to the method in "LightSABRE: A Lightweight and Enhanced SABRE Algorithm", Henry Zou, Matthew Treinish, Kevin Hartman, Alexander Ivrii, Jake Lishman, arXiv:2409.08368.
 
-**Note:** The {py:meth}`~AerBackend.default_compilation_pass` for {py:class}`AerBackend` is the same as above.
+**Note:** The {py:meth}`~AerBackend.default_compilation_pass` for {py:class}`AerBackend` is the same as above if a {py:class}`NoiseModel` is used. A {py:class}`NoiseModel` implicitly defines connectivity constraints via edge errors. If no {py:class}`NoiseModel` is used then then any passes related to connectivity constraints are omitted from the {py:meth}`~AerBackend.default_compilation_pass` for {py:class}`AerBackend`.
 
 ## Noise Modelling
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -871,6 +871,10 @@ def tk_to_qiskit(
     If no exact replacement can be found for a part of the circuit then an equivalent
     circuit will be returned using the tket gates which are supported in qiskit.
 
+    Please note that implicit swaps in a pytket Circuit are not handled by default.
+    Consider using the replace_implicit_swaps to replace these implicit swaps with
+    SWAP gates.
+
     :param tkcirc: A :py:class:`Circuit` to be converted
     :param replace_implicit_swaps: Implement implicit permutation by adding SWAPs
         to the end of the circuit.

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -15,7 +15,6 @@
 
 """Methods to allow conversion between Qiskit and pytket circuit classes
 """
-import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from inspect import signature

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -862,10 +862,6 @@ _protected_tket_gates = (
 supported_gate_rebase = AutoRebase(_protected_tket_gates)
 
 
-def _has_implicit_permutation(circ: Circuit) -> bool:
-    return any(q0 != q1 for q0, q1 in circ.implicit_qubit_permutation().items())
-
-
 def tk_to_qiskit(
     tkcirc: Circuit, replace_implicit_swaps: bool = False
 ) -> QuantumCircuit:
@@ -884,14 +880,6 @@ def tk_to_qiskit(
     tkc = tkcirc.copy()  # Make a local copy of tkcirc
     if replace_implicit_swaps:
         tkc.replace_implicit_wire_swaps()
-
-    if _has_implicit_permutation(tkcirc) and not replace_implicit_swaps:
-        warnings.warn(
-            "The pytket Circuit contains implicit qubit permutations"
-            + " which aren't handled by default."
-            + " Consider using the replace_implicit_swaps flag in tk_to_qiskit or"
-            + " replacing them using Circuit.replace_implicit_swaps()."
-        )
 
     qcirc = QuantumCircuit(name=tkc.name)
     qreg_sizes: dict[str, int] = {}

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -872,7 +872,7 @@ def tk_to_qiskit(
     circuit will be returned using the tket gates which are supported in qiskit.
 
     Please note that implicit swaps in a pytket Circuit are not handled by default.
-    Consider using the replace_implicit_swaps to replace these implicit swaps with
+    Consider using the replace_implicit_swaps flag to replace these implicit swaps with
     SWAP gates.
 
     :param tkcirc: A :py:class:`Circuit` to be converted

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1172,10 +1172,3 @@ def test_nonregister_bits() -> None:
     c.rename_units({Bit(0): Bit(1)})
     with pytest.raises(NotImplementedError):
         tk_to_qiskit(c)
-
-
-def test_implicit_swap_warning() -> None:
-    c = Circuit(2).H(0).SWAP(0, 1)
-    c.replace_SWAPs()
-    with pytest.warns(UserWarning, match="The pytket Circuit contains implicit qubit"):
-        tk_to_qiskit(c)


### PR DESCRIPTION
# Description

reverts #412 

See explanation here -> https://github.com/CQCL/pytket-qiskit/issues/411#issuecomment-2488799379

Drive by: Clarify how the default pass works in the docs for `AerBackend` when no `NoiseModel` is used.

# Related issues

#411 

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
