### PR TITLE
fix: improve implicit qubit permutations warning

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,8 @@
 
 ## 0.60.0 (Unreleased)
 
-- Revert a change made in release v0.59.0 where users are warned about implicit qubit permutations in {py:func}`tk_to_qiskit`. This avoids spamming the user with unhelpful warnings when using pytket-qiskit backends. These backends handle implicit permutations automatically.
+- Fix an unhelpful warning message about implicit swaps when using optimisation level 2 with {py:class}`AerBackend`
+- Add a boolean `perm_warn` argument to {py:func}`tk_to_qiskit` indicating whether to give a warning if the input {py:class}`Circuit` has an implicit qubit permutation.
 - Add new level 3 optimisation that uses `GreedyPauliSimp`
 
 ## 0.59.0 (November 2024)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,7 +7,7 @@
 ## 0.60.0 (Unreleased)
 
 - Fix an unhelpful warning message about implicit swaps when using optimisation level 2 with {py:class}`AerBackend`
-- Add a boolean `perm_warn` argument to {py:func}`tk_to_qiskit` indicating whether to give a warning if the input {py:class}`Circuit` has an implicit qubit permutation.
+- Add a boolean `perm_warning` argument to {py:func}`tk_to_qiskit` indicating whether to give a warning if the input {py:class}`Circuit` has an implicit qubit permutation.
 - Add new level 3 optimisation that uses `GreedyPauliSimp`
 
 ## 0.59.0 (November 2024)

--- a/docs/index.md
+++ b/docs/index.md
@@ -194,7 +194,7 @@ Every {py:class}`~pytket.backends.backend.Backend` in pytket has its own {py:met
 2 preserve barriers in a circuit, while optimisation level 3 will remove them.
 
 :::{list-table} **Default compilation pass for the IBMQBackend and IBMQEmulatorBackend**
-:widths: 25 25 25
+:widths: 25 25 25 25
 :header-rows: 1
 
 * - optimisation_level = 0
@@ -208,7 +208,7 @@ Every {py:class}`~pytket.backends.backend.Backend` in pytket has its own {py:met
 * - [AutoRebase [2]](inv:#*.AutoRebase)
   - [SynthesiseTket](inv:#*.SynthesiseTket)
   - [FullPeepholeOptimise](inv:#*.passes.FullPeepholeOptimise)
-  - [RemoveBarriers](inv:#*.passes.RmoveBarriers)
+  - [RemoveBarriers](inv:#*pytket._tket.passes.RemoveBarriers)
 * - LightSabre [3]
   - LightSabre [3]
   - LightSabre [3]

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -286,7 +286,7 @@ class _AerBaseBackend(Backend):
         circuit_batches, batch_order = _batch_circuits(circuits, n_shots_list)
 
         replace_implicit_swaps = self.supports_state or self.supports_unitary
-        perm_warning = replace_implicit_swaps
+        perm_warning = False
 
         for (n_shots, batch), indices in zip(circuit_batches, batch_order):
             qcs, ppcirc_strs, tkc_qubits_count = [], [], []

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -286,7 +286,6 @@ class _AerBaseBackend(Backend):
         circuit_batches, batch_order = _batch_circuits(circuits, n_shots_list)
 
         replace_implicit_swaps = self.supports_state or self.supports_unitary
-        perm_warning = False
 
         for (n_shots, batch), indices in zip(circuit_batches, batch_order):
             qcs, ppcirc_strs, tkc_qubits_count = [], [], []
@@ -297,7 +296,7 @@ class _AerBaseBackend(Backend):
                 else:
                     c0, ppcirc_rep = tkc, None
 
-                qc = tk_to_qiskit(c0, replace_implicit_swaps, perm_warning)
+                qc = tk_to_qiskit(c0, replace_implicit_swaps, perm_warning=False)
 
                 if self.supports_state:
                     qc.save_state()

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -286,6 +286,7 @@ class _AerBaseBackend(Backend):
         circuit_batches, batch_order = _batch_circuits(circuits, n_shots_list)
 
         replace_implicit_swaps = self.supports_state or self.supports_unitary
+        perm_warning = replace_implicit_swaps
 
         for (n_shots, batch), indices in zip(circuit_batches, batch_order):
             qcs, ppcirc_strs, tkc_qubits_count = [], [], []
@@ -296,7 +297,7 @@ class _AerBaseBackend(Backend):
                 else:
                     c0, ppcirc_rep = tkc, None
 
-                qc = tk_to_qiskit(c0, replace_implicit_swaps)
+                qc = tk_to_qiskit(c0, replace_implicit_swaps, perm_warning)
 
                 if self.supports_state:
                     qc.save_state()

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -886,8 +886,8 @@ def tk_to_qiskit(
     :param tkcirc: A :py:class:`Circuit` to be converted
     :param replace_implicit_swaps: Implement implicit permutation by adding SWAPs
         to the end of the circuit.
-    :param perm_warnings: Warn if an input circuit has implicit qubit permutations, True by
-        default.
+    :param perm_warnings: Warn if an input circuit has implicit qubit permutations,
+        True by default.
     :return: The converted circuit
     """
     tkc = tkcirc.copy()  # Make a local copy of tkcirc

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -863,7 +863,8 @@ supported_gate_rebase = AutoRebase(_protected_tket_gates)
 
 
 def _has_implicit_permutation(circ: Circuit) -> bool:
-    """Returns True if a Circuit has a non-trivial permutation of qubits, false otherwise."""
+    """Returns True if a Circuit has a non-trivial permutation 
+        of qubits, false otherwise."""
     return any(q0 != q1 for q0, q1 in circ.implicit_qubit_permutation().items())
 
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -868,7 +868,9 @@ def _has_implicit_permutation(circ: Circuit) -> bool:
 
 
 def tk_to_qiskit(
-    tkcirc: Circuit, replace_implicit_swaps: bool = False, perm_warning: bool = True,
+    tkcirc: Circuit,
+    replace_implicit_swaps: bool = False,
+    perm_warning: bool = True,
 ) -> QuantumCircuit:
     """
     Converts a pytket :py:class:`Circuit` to a qiskit :py:class:`qiskit.QuantumCircuit`.
@@ -892,7 +894,11 @@ def tk_to_qiskit(
     if replace_implicit_swaps:
         tkc.replace_implicit_wire_swaps()
 
-    if _has_implicit_permutation(tkcirc) and perm_warning and not replace_implicit_swaps:
+    if (
+        _has_implicit_permutation(tkcirc)
+        and perm_warning
+        and not replace_implicit_swaps
+    ):
         warnings.warn(
             "The pytket Circuit contains implicit qubit permutations"
             + " which aren't handled by default."

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -887,7 +887,7 @@ def tk_to_qiskit(
     :param tkcirc: A :py:class:`Circuit` to be converted
     :param replace_implicit_swaps: Implement implicit permutation by adding SWAPs
         to the end of the circuit.
-    :param perm_warnings: Warn if an input circuit has implicit qubit permutations,
+    :param perm_warning: Warn if an input circuit has implicit qubit permutations,
         and `replace_implicit_swaps` is `False`. True by default.
     :return: The converted circuit
     """

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -892,7 +892,7 @@ def tk_to_qiskit(
     if replace_implicit_swaps:
         tkc.replace_implicit_wire_swaps()
 
-    if _has_implicit_permutation(tkcirc) and perm_warning not replace_implicit_swaps:
+    if _has_implicit_permutation(tkcirc) and perm_warning and not replace_implicit_swaps:
         warnings.warn(
             "The pytket Circuit contains implicit qubit permutations"
             + " which aren't handled by default."

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -884,6 +884,8 @@ def tk_to_qiskit(
     :param tkcirc: A :py:class:`Circuit` to be converted
     :param replace_implicit_swaps: Implement implicit permutation by adding SWAPs
         to the end of the circuit.
+    :param perm_warnings: Warn on if input circuit has implicit qubit permutations, True by
+        default.
     :return: The converted circuit
     """
     tkc = tkcirc.copy()  # Make a local copy of tkcirc

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -863,8 +863,8 @@ supported_gate_rebase = AutoRebase(_protected_tket_gates)
 
 
 def _has_implicit_permutation(circ: Circuit) -> bool:
-    """Returns True if a Circuit has a non-trivial permutation 
-        of qubits, false otherwise."""
+    """Returns True if a Circuit has a non-trivial permutation
+    of qubits, false otherwise."""
     return any(q0 != q1 for q0, q1 in circ.implicit_qubit_permutation().items())
 
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -15,6 +15,7 @@
 
 """Methods to allow conversion between Qiskit and pytket circuit classes
 """
+import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from inspect import signature
@@ -862,6 +863,7 @@ supported_gate_rebase = AutoRebase(_protected_tket_gates)
 
 
 def _has_implicit_permutation(circ: Circuit) -> bool:
+    """Returns True if a Circuit has a non-trivial permutation of qubits, false otherwise."""
     return any(q0 != q1 for q0, q1 in circ.implicit_qubit_permutation().items())
 
 

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -888,7 +888,7 @@ def tk_to_qiskit(
     :param replace_implicit_swaps: Implement implicit permutation by adding SWAPs
         to the end of the circuit.
     :param perm_warnings: Warn if an input circuit has implicit qubit permutations,
-        True by default.
+        and `replace_implicit_swaps` is `False`. True by default.
     :return: The converted circuit
     """
     tkc = tkcirc.copy()  # Make a local copy of tkcirc

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -890,7 +890,7 @@ def tk_to_qiskit(
     if replace_implicit_swaps:
         tkc.replace_implicit_wire_swaps()
 
-    if _has_implicit_permutation(tkcirc) and perm_warning and not replace_implicit_swaps:
+    if _has_implicit_permutation(tkcirc) and perm_warning not replace_implicit_swaps:
         warnings.warn(
             "The pytket Circuit contains implicit qubit permutations"
             + " which aren't handled by default."

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -884,7 +884,7 @@ def tk_to_qiskit(
     :param tkcirc: A :py:class:`Circuit` to be converted
     :param replace_implicit_swaps: Implement implicit permutation by adding SWAPs
         to the end of the circuit.
-    :param perm_warnings: Warn on if input circuit has implicit qubit permutations, True by
+    :param perm_warnings: Warn if an input circuit has implicit qubit permutations, True by
         default.
     :return: The converted circuit
     """

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import warnings
 from collections import Counter
 from math import pi
 
@@ -64,7 +65,6 @@ from pytket.circuit import (
 from pytket.extensions.qiskit import IBMQBackend, qiskit_to_tk, tk_to_qiskit
 from pytket.extensions.qiskit.backends import (
     qiskit_aer_backend,
-    AerStateBackend,
     AerBackend,
 )
 from pytket.extensions.qiskit.qiskit_convert import _gate_str_2_optype
@@ -1178,9 +1178,9 @@ def test_implicit_swap_warning() -> None:
         tk_to_qiskit(c)
 
     shots_backend = AerBackend()
-    with pytest.warns(UserWarning) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         shots_backend.run_circuit(c)
-        assert len(record) == 0
 
 
 # https://github.com/CQCL/pytket-qiskit/issues/337

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -62,7 +62,11 @@ from pytket.circuit import (
     reg_eq,
 )
 from pytket.extensions.qiskit import IBMQBackend, qiskit_to_tk, tk_to_qiskit
-from pytket.extensions.qiskit.backends import qiskit_aer_backend, AerStateBackend, AerBackend
+from pytket.extensions.qiskit.backends import (
+    qiskit_aer_backend,
+    AerStateBackend,
+    AerBackend,
+)
 from pytket.extensions.qiskit.qiskit_convert import _gate_str_2_optype
 from pytket.extensions.qiskit.result_convert import qiskit_result_to_backendresult
 from pytket.extensions.qiskit.tket_pass import TketAutoPass, TketPass
@@ -1164,6 +1168,7 @@ def test_symbolic_param_conv() -> None:
             for i in range(len(qc_transpiled_again.parameters))
         }
     )
+
 
 def test_implicit_swap_warning() -> None:
     c = Circuit(2).H(0).SWAP(0, 1)

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1169,19 +1169,14 @@ def test_symbolic_param_conv() -> None:
 def test_implicit_swap_warning() -> None:
     c = Circuit(2).H(0).SWAP(0, 1)
     c.replace_SWAPs()
+    c.measure_all()
     with pytest.warns(UserWarning, match="The pytket Circuit contains implicit qubit"):
         tk_to_qiskit(c)
 
-    state_backend = AerStateBackend()
     shots_backend = AerBackend()
     with pytest.warns(UserWarning) as record:
-        state_backend.run_circuit(c)
-        c.measure_all()
         shots_backend.run_circuit(c)
         assert len(record) == 0
-
-
-
 
 
 # https://github.com/CQCL/pytket-qiskit/issues/337

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -64,8 +64,8 @@ from pytket.circuit import (
 )
 from pytket.extensions.qiskit import IBMQBackend, qiskit_to_tk, tk_to_qiskit
 from pytket.extensions.qiskit.backends import (
-    qiskit_aer_backend,
     AerBackend,
+    qiskit_aer_backend,
 )
 from pytket.extensions.qiskit.qiskit_convert import _gate_str_2_optype
 from pytket.extensions.qiskit.result_convert import qiskit_result_to_backendresult

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import warnings
 from collections import Counter
 from math import pi
 
@@ -62,7 +63,7 @@ from pytket.circuit import (
     reg_eq,
 )
 from pytket.extensions.qiskit import IBMQBackend, qiskit_to_tk, tk_to_qiskit
-from pytket.extensions.qiskit.backends import qiskit_aer_backend
+from pytket.extensions.qiskit.backends import qiskit_aer_backend, AerStateBackend, AerBackend
 from pytket.extensions.qiskit.qiskit_convert import _gate_str_2_optype
 from pytket.extensions.qiskit.result_convert import qiskit_result_to_backendresult
 from pytket.extensions.qiskit.tket_pass import TketAutoPass, TketPass
@@ -1164,6 +1165,23 @@ def test_symbolic_param_conv() -> None:
             for i in range(len(qc_transpiled_again.parameters))
         }
     )
+
+def test_implicit_swap_warning() -> None:
+    c = Circuit(2).H(0).SWAP(0, 1)
+    c.replace_SWAPs()
+    with pytest.warns(UserWarning, match="The pytket Circuit contains implicit qubit"):
+        tk_to_qiskit(c)
+
+    state_backend = AerStateBackend()
+    shots_backend = AerBackend()
+    with pytest.warns(UserWarning) as record:
+        state_backend.run_circuit(c)
+        c.measure_all()
+        shots_backend.run_circuit(c)
+        assert len(record) == 0
+
+
+
 
 
 # https://github.com/CQCL/pytket-qiskit/issues/337

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import warnings
 from collections import Counter
 from math import pi
 


### PR DESCRIPTION
# Description

Added the change from #412 back in again with a boolean flag to ensure that unhelpful warnings aren't generated when using `AerBackend` with optimisation level 2

See discusssion in #411 

Driveby: fix invalid table of compilation passes (see [df0cda3](https://github.com/CQCL/pytket-qiskit/pull/421/commits/df0cda3d1c46d8cbe5d69c9e9f43990cdd846bc7))

# Related issues

closes #411 

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
