### PR TITLE
Go back to qiskit 1.2.4.

### DIFF
--- a/_metadata.py
+++ b/_metadata.py
@@ -1,2 +1,2 @@
-__extension_version__ = "0.60.0"
+__extension_version__ = "0.61.0"
 __extension_name__ = "pytket-qiskit"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@
 
 # Changelog
 
+## 0.61.0 (December 2024)
+
+- Restrict qiskit version to ~= 1.24. to avoid braking changes in 1.3.0
+
 ## 0.60.0 (November 2024)
 
 - Fix an unhelpful warning message about implicit swaps when using optimisation level 2 with {py:class}`AerBackend`

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket >= 1.35.0",
-        "qiskit >= 1.2.4",
+        "qiskit =~ 1.2.4",
         "qiskit-ibm-runtime >= 0.30.0",
         "qiskit-aer >= 0.15.1",
         "numpy >= 1.26.4",


### PR DESCRIPTION
# Description

There are some issues with qiskit 1.3.0 which require some bigger changes, I would suggest to go back to 1.2.4. and update later on.

I am not really sure that the changes are intended, from the documentation this should have only been deprecated, but removed.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
