### PR TITLE
docs: replace `_tket` links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -208,7 +208,7 @@ Every {py:class}`~pytket.backends.backend.Backend` in pytket has its own {py:met
 * - [AutoRebase [2]](inv:#*.AutoRebase)
   - [SynthesiseTket](inv:#*.SynthesiseTket)
   - [FullPeepholeOptimise](inv:#*.passes.FullPeepholeOptimise)
-  - [RemoveBarriers](inv:#*pytket._tket.passes.RemoveBarriers)
+  - [RemoveBarriers](inv:#*pytket.passes.RemoveBarriers)
 * - LightSabre [3]
   - LightSabre [3]
   - LightSabre [3]
@@ -242,7 +242,7 @@ Every {py:class}`~pytket.backends.backend.Backend` in pytket has its own {py:met
 :::
 
 - \[1\] If no value is specified then `optimisation_level` defaults to a value of 2.
-- \[2\] {py:class}`~pytket._tket.passes.AutoRebase` is a conversion to the gateset supported by the backend. For IBM quantum devices and emulators the supported gate set is either $\{X, SX, Rz, CX\}$, $\{X, SX, Rz, ECR\}$, or $\{X, SX, Rz, CZ\}$. The more idealised Aer simulators have a much broader range of supported gates.
+- \[2\] {py:class}`~pytket.passes.AutoRebase` is a conversion to the gateset supported by the backend. For IBM quantum devices and emulators the supported gate set is either $\{X, SX, Rz, CX\}$, $\{X, SX, Rz, ECR\}$, or $\{X, SX, Rz, CZ\}$. The more idealised Aer simulators have a much broader range of supported gates.
 - \[3\] This is imported from qiskit and corresponds to the method in "LightSABRE: A Lightweight and Enhanced SABRE Algorithm", Henry Zou, Matthew Treinish, Kevin Hartman, Alexander Ivrii, Jake Lishman, arXiv:2409.08368.
 
 **Note:** The {py:meth}`~AerBackend.default_compilation_pass` for {py:class}`AerBackend` is the same as above if a {py:class}`NoiseModel` is used. A {py:class}`NoiseModel` implicitly defines connectivity constraints via edge errors. If no {py:class}`NoiseModel` is used then then any passes related to connectivity constraints are omitted from the {py:meth}`~AerBackend.default_compilation_pass` for {py:class}`AerBackend`.


### PR DESCRIPTION
# Description

These should no longer be necessary after this prefix is removed from the docs

see https://github.com/CQCL/tket/issues/1719
