### PR TITLE
Compare unitaries up to global phase.

### DIFF
--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1052,7 +1052,7 @@ def _verify_single_q_rebase(
     circ.add_gate(OpType.TK1, [a, b, c], [0])
     backend.rebase_pass().apply(circ)
     u_after = backend.run_circuit(circ).get_unitary()
-    return np.allclose(u_before, u_after)
+    return compare_unitaries(u_before, u_after)
 
 
 def test_rebase_phase() -> None:


### PR DESCRIPTION
Fixes #428 .

Must have been a change in the Aer unitary simulator causing the global phase computation to change.