### PR TITLE
Use `MCMTGate` instead of deprecated `MCMT`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,9 @@
 
 ## unreleased
 
-- AerBackend now reject circuits with too many qubits 
+- AerBackend now reject circuits with too many qubits
+- Update pytket version requirement to 1.37.0.
+- Update qiskit version requirement to 1.3.1.
 
 ## 0.61.0 (December 2024)
 

--- a/setup.py
+++ b/setup.py
@@ -46,8 +46,8 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket >= 1.35.0",
-        "qiskit ~= 1.2.4",
+        "pytket >= 1.37.0",
+        "qiskit ~= 1.3.1",
         "qiskit-ibm-runtime >= 0.30.0",
         "qiskit-aer >= 0.15.1",
         "numpy >= 1.26.4",

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1170,6 +1170,7 @@ def test_symbolic_param_conv() -> None:
     )
 
 
+@pytest.mark.xfail(reason="https://github.com/CQCL/pytket-qiskit/issues/427")
 def test_implicit_swap_warning() -> None:
     c = Circuit(2).H(0).SWAP(0, 1)
     c.replace_SWAPs()

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -691,6 +691,7 @@ def qcirc_to_tcirc(qcirc: QuantumCircuit) -> Circuit:
     return tcirc
 
 
+@pytest.mark.xfail(reason="https://github.com/Qiskit/qiskit/issues/13563")
 def test_cnry_conversion() -> None:
     """This is for TKET-991.
     Maintain parallel circuits, check equivalence at each stage.

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -30,7 +30,7 @@ from qiskit.circuit.equivalence_library import (  # type: ignore
     StandardEquivalenceLibrary,
 )
 from qiskit.circuit.library import (
-    MCMT,
+    MCMTGate,
     PauliEvolutionGate,
     RealAmplitudes,
     RYGate,
@@ -613,7 +613,7 @@ def add_cnry(
         else:
             # param was "raw", so needs an extra PI.
             new_ry_gate = RYGate(param * pi)
-            new_gate = MCMT(
+            new_gate = MCMTGate(
                 gate=new_ry_gate, num_ctrl_qubits=len(qbits) - 1, num_target_qubits=1
             )
             circ.append(new_gate, [qr[nn] for nn in qbits])
@@ -691,7 +691,6 @@ def qcirc_to_tcirc(qcirc: QuantumCircuit) -> Circuit:
     return tcirc
 
 
-@pytest.mark.xfail(reason="https://github.com/Qiskit/qiskit/issues/13563")
 def test_cnry_conversion() -> None:
     """This is for TKET-991.
     Maintain parallel circuits, check equivalence at each stage.


### PR DESCRIPTION
We need to update to qiskit 1.3.1 in order to use it.

Closes #429 .
Closes #431 .