### PR TITLE
Raise error when converting nested conditionals

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@
 
 # Changelog
 
+## Unreleased
+
+- Reject circuits containing nested conditionals when converting to qiskit.
+
 ## 0.62.0 (December 2024)
 
 - AerBackend now rejects circuits with too many qubits

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -47,6 +47,7 @@ from pytket.circuit import (
     Bit,
     CircBox,
     Circuit,
+    Conditional,
     Node,
     Op,
     OpType,
@@ -741,26 +742,27 @@ def append_tk_command_to_qiskit(
         # subsequent conditional will handle it
         return Instruction("", 0, 0, [])
     if optype == OpType.Conditional:
+        assert isinstance(op, Conditional)
         if op.op.type == OpType.Conditional:
             # See https://github.com/CQCL/pytket-qiskit/issues/442
             raise NotImplementedError("Nested conditional not supported")
-        if op.op.type == OpType.Phase:  # type: ignore
+        if op.op.type == OpType.Phase:
             # conditional phase not supported
             return InstructionSet()
         if args[0] in range_preds:
-            assert op.value == 1  # type: ignore
+            assert op.value == 1
             condition_bits, value = range_preds[args[0]]  # type: ignore
             args = condition_bits + args[1:]
             width = len(condition_bits)
         else:
-            width = op.width  # type: ignore
-            value = op.value  # type: ignore
+            width = op.width
+            value = op.value
         regname = args[0].reg_name
         for i, a in enumerate(args[:width]):
             if a.reg_name != regname:
                 raise NotImplementedError("Conditions can only use a single register")
         instruction = append_tk_command_to_qiskit(
-            op.op,  # type: ignore
+            op.op,
             args[width:],
             qcirc,
             qregmap,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -741,6 +741,9 @@ def append_tk_command_to_qiskit(
         # subsequent conditional will handle it
         return Instruction("", 0, 0, [])
     if optype == OpType.Conditional:
+        if op.op.type == OpType.Conditional:
+            # See https://github.com/CQCL/pytket-qiskit/issues/442
+            raise NotImplementedError("Nested conditional not supported")
         if op.op.type == OpType.Phase:  # type: ignore
             # conditional phase not supported
             return InstructionSet()

--- a/tests/qiskit_convert_test.py
+++ b/tests/qiskit_convert_test.py
@@ -1204,3 +1204,15 @@ def test_range_preds_with_conditionals() -> None:
     assert len(qkc) == 2
     assert len(qkc.qubits) == 1
     assert len(qkc.clbits) == 1
+
+
+def test_nested_conditionals() -> None:
+    # https://github.com/CQCL/pytket-qiskit/issues/442
+    c0 = Circuit(1, 1).X(0, condition_bits=[0], condition_value=1)
+    cbox = CircBox(c0)
+    c = Circuit(1, 2)
+    c.add_circbox(cbox, [Qubit(0), Bit(1)], condition_bits=[Bit(0)], condition_value=1)
+    DecomposeBoxes().apply(c)
+    with pytest.raises(NotImplementedError):
+        # For now we do not support conversion of nested conditionals.
+        _qkc = tk_to_qiskit(c)


### PR DESCRIPTION
See #442 .

It would be good to support this, but better to raise an error than to convert incorrectly.