### PR TITLE
Add support for "fractional gates"

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@
 
 - Reject circuits containing nested conditionals when converting to qiskit.
 - Update pytket version requirement to 1.38.0. 
+- Add support for fractional gates on backends that support them.
 
 ## 0.62.0 (December 2024)
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -161,6 +161,9 @@ class IBMQBackend(Backend):
         See the Qiskit documentation at
         https://docs.quantum.ibm.com/api/qiskit-ibm-runtime/qiskit_ibm_runtime.options.SamplerOptions
         for details and default values.
+    :param use_fractional_gates: Whether to use native "fractional gates" on the device
+        if available. See https://docs.quantum.ibm.com/guides/fractional-gates (default
+        False).
     """
 
     _supports_shots = False
@@ -176,6 +179,7 @@ class IBMQBackend(Backend):
         service: Optional[QiskitRuntimeService] = None,
         token: Optional[str] = None,
         sampler_options: SamplerOptions = None,
+        use_fractional_gates: bool = False,
     ):
         super().__init__()
         self._pytket_config = QiskitConfig.from_default_config_file()
@@ -184,7 +188,9 @@ class IBMQBackend(Backend):
             if service is None
             else service
         )
-        self._backend: IBMBackend = self._service.backend(backend_name)
+        self._backend: IBMBackend = self._service.backend(
+            backend_name, use_fractional_gates=use_fractional_gates
+        )
         config: PulseBackendConfiguration = self._backend.configuration()
         self._max_per_job = getattr(config, "max_experiments", 1)
 

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -58,6 +58,7 @@ class IBMQEmulatorBackend(Backend):
         instance: Optional[str] = None,
         service: Optional["QiskitRuntimeService"] = None,
         token: Optional[str] = None,
+        use_fractional_gates: bool = False,
     ):
         super().__init__()
         self._ibmq = IBMQBackend(
@@ -65,6 +66,7 @@ class IBMQEmulatorBackend(Backend):
             instance=instance,
             service=service,
             token=token,
+            use_fractional_gates=use_fractional_gates,
         )
 
         # Get noise model:


### PR DESCRIPTION
Closes #413 .
The test failure is unrelated: see #449 .
It is not currently possible to add a CI test for this as none of the devices on the open plan support fractional gates. But I have tested locally with `ibm_torino`.
In addition, I have added a squashing step to the default compilation passes, since they were not squashing single-qubit gates (as pointed out in the comments on the issue).