### PR TITLE
Allow versions of qiskit >= 1.3.1 but < 2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "pytket >= 1.39.0",
-        "qiskit ~= 1.3.1",
+        "qiskit >= 1.3.1, < 2",
         "qiskit-ibm-runtime >= 0.30.0",
         "qiskit-aer >= 0.15.1",
         "numpy >= 1.26.4",


### PR DESCRIPTION
This relaxes the condition in line with the general policy of having upper bounds only when known to be necessary. The upper bound of 2 _is_ needed bacause qiskit 2 will remove some things like `Instruction.c_if()` that we depend on, and we can't yet remove that dependence because of limitations in current qiskit. (I've made a [qiskit-2 branch](https://github.com/CQCL/pytket-qiskit/tree/ae/qiskit-2) which we can hopefully merge after the release of qiskit 2.)