### PR TITLE
docs: fix link for `RemoveBarriers` pass, update docs build scripts

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -15,6 +15,14 @@ sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    find build/ -type f -name "*.html" | xargs sed -e 's/pytket._tket/pytket/g' -i ""
+    sed -i '' 's/pytket._tket/pytket/g' build/searchindex.js
+else
+    find build/ -type f -name "*.html" | xargs sed -i 's/pytket._tket/pytket/g'
+    sed -i 's/pytket._tket/pytket/g' build/searchindex.js
+fi
+
 # Remove copied files. This ensures reusability.
 rm -r _static 
 rm -r quantinuum-sphinx

--- a/docs/index.md
+++ b/docs/index.md
@@ -208,7 +208,7 @@ Every {py:class}`~pytket.backends.backend.Backend` in pytket has its own {py:met
 * - [AutoRebase [2]](inv:#*.AutoRebase)
   - [SynthesiseTket](inv:#*.SynthesiseTket)
   - [FullPeepholeOptimise](inv:#*.passes.FullPeepholeOptimise)
-  - [RemoveBarriers](inv:#*pytket.passes.RemoveBarriers)
+  - [RemoveBarriers](inv:#*pytket._tket.passes.RemoveBarriers)
 * - LightSabre [3]
   - LightSabre [3]
   - LightSabre [3]

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 
-"""Methods to allow conversion between Qiskit and pytket circuit classes
-"""
+"""Methods to allow conversion between Qiskit and pytket circuit classes"""
 import warnings
 from collections import defaultdict
 from collections.abc import Iterable


### PR DESCRIPTION
# Description

1.  Picking up the docs link fix from https://github.com/CQCL/pytket-qiskit/pull/443 so we don't have to wait for the docs build in C.I. to be fixed.
2. Update docs theming submodule
3. update the docs build script to replace all `_tket` links for the passes in the default compilation table

Only (1.) affects the website. Everything else is just for the docs build in pytket-qiskit. This is still broken. See #458 

Drive by: black format the `qiskit_convert.py` file after a `black` package update.

closes #444 