### PR TITLE
Update to qiskit ibm runtime 0.37.0

### DIFF
--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -458,13 +458,13 @@ class _AerBaseBackend(Backend):
                 handle_list[ind] = handle
                 self._circuit_data[(jobid, i)] = (tkc_qubits_count[i], ppcirc_strs[i])
                 self._cache[handle] = {"job": job}
-        return cast(list[ResultHandle], handle_list)
+        return cast("list[ResultHandle]", handle_list)
 
     def cancel(self, handle: ResultHandle) -> None:
         job: AerJob = self._cache[handle]["job"]
         cancelled = job.cancel()
         if not cancelled:
-            warning(f"Unable to cancel job {cast(str, handle[0])}")
+            warning(f"Unable to cancel job {cast('str', handle[0])}")
 
     def circuit_status(self, handle: ResultHandle) -> CircuitStatus:
         self._check_handle_type(handle)
@@ -497,7 +497,7 @@ class _AerBaseBackend(Backend):
                     "result"
                 ] = backres
 
-            return cast(BackendResult, self._cache[handle]["result"])
+            return cast("BackendResult", self._cache[handle]["result"])
 
     def _snapshot_expectation_value(
         self,
@@ -519,7 +519,7 @@ class _AerBaseBackend(Backend):
         qc.save_expectation_value(hamiltonian, qc.qubits, "snap")
         job = self._qiskit_backend.run(qc)
         return cast(
-            complex,
+            "complex",
             job.result().data(qc)["snap"],
         )
 
@@ -906,7 +906,7 @@ def _process_noise_model(
                 )
             elif error["type"] == "roerror":
                 readout_errors[Node(q)] = cast(
-                    list[list[float]], error["probabilities"]
+                    "list[list[float]]", error["probabilities"]
                 )
             else:
                 raise RuntimeWarning("Error type not 'qerror' or 'roerror'.")

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -657,14 +657,14 @@ class IBMQBackend(Backend):
         for handle in handle_list:
             assert handle is not None
             self._cache[handle] = dict()
-        return cast(list[ResultHandle], handle_list)
+        return cast("list[ResultHandle]", handle_list)
 
     def _retrieve_job(self, jobid: str) -> RuntimeJob:
         return self._service.job(jobid)
 
     def cancel(self, handle: ResultHandle) -> None:
         if not self._MACHINE_DEBUG:
-            jobid = cast(str, handle[0])
+            jobid = cast("str", handle[0])
             job = self._retrieve_job(jobid)
             try:
                 job.cancel()
@@ -673,7 +673,7 @@ class IBMQBackend(Backend):
 
     def circuit_status(self, handle: ResultHandle) -> CircuitStatus:
         self._check_handle_type(handle)
-        jobid = cast(str, handle[0])
+        jobid = cast("str", handle[0])
         job = self._service.job(jobid)
         ibmstatus = job.status()
         return CircuitStatus(_STATUS_MAP[ibmstatus], ibmstatus)
@@ -687,7 +687,7 @@ class IBMQBackend(Backend):
         if handle in self._cache:
             cached_result = self._cache[handle]
             if "result" in cached_result:
-                return cast(BackendResult, cached_result["result"])
+                return cast("BackendResult", cached_result["result"])
         jobid, index, n_bits, ppcirc_str = handle
         ppcirc_rep = json.loads(ppcirc_str)
         ppcirc = Circuit.from_dict(ppcirc_rep) if ppcirc_rep is not None else None

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -35,7 +35,7 @@ from qiskit_ibm_runtime import (  # type: ignore
     Session,
 )
 from qiskit_ibm_runtime.models.backend_configuration import (  # type: ignore
-    PulseBackendConfiguration,
+    QasmBackendConfiguration,
 )
 from qiskit_ibm_runtime.models.backend_properties import (  # type: ignore
     BackendProperties,
@@ -195,7 +195,7 @@ class IBMQBackend(Backend):
         self._backend: IBMBackend = self._service.backend(
             backend_name, use_fractional_gates=use_fractional_gates
         )
-        config: PulseBackendConfiguration = self._backend.configuration()
+        config: QasmBackendConfiguration = self._backend.configuration()
         self._max_per_job = getattr(config, "max_experiments", 1)
 
         gate_set = _tk_gate_set(config)
@@ -243,7 +243,7 @@ class IBMQBackend(Backend):
     @classmethod
     def _get_backend_info(
         cls,
-        config: PulseBackendConfiguration,
+        config: QasmBackendConfiguration,
         props: Optional[BackendProperties],
     ) -> BackendInfo:
         """Construct a BackendInfo from data returned by the IBMQ API.
@@ -386,7 +386,7 @@ class IBMQBackend(Backend):
 
         :return: Compilation pass guaranteeing required predicates.
         """
-        config: PulseBackendConfiguration = self._backend.configuration()
+        config: QasmBackendConfiguration = self._backend.configuration()
         props: Optional[BackendProperties] = self._backend.properties()
         return IBMQBackend.default_compilation_pass_offline(
             config, props, optimisation_level, timeout
@@ -394,7 +394,7 @@ class IBMQBackend(Backend):
 
     @staticmethod
     def default_compilation_pass_offline(
-        config: PulseBackendConfiguration,
+        config: QasmBackendConfiguration,
         props: Optional[BackendProperties],
         optimisation_level: int = 2,
         timeout: int = 300,

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -650,7 +650,7 @@ class CircuitBuilder:
                 self.tkc.add_circbox(ccbox, qubits)
 
             elif type(instr) is UnitaryGate:
-                unitary = cast(NDArray[np.complex128], instr.params[0])
+                unitary = cast("NDArray[np.complex128]", instr.params[0])
                 if len(qubits) == 0:
                     # If the UnitaryGate acts on no qubits, we add a phase.
                     self.tkc.add_phase(np.angle(unitary[0][0]) / np.pi)
@@ -703,7 +703,7 @@ def qiskit_to_tk(qcirc: QuantumCircuit, preserve_param_uuid: bool = False) -> Ci
     # we optionally preserve this in parameter name for later use
     if preserve_param_uuid:
         updates = {p: Parameter(f"{p.name}_UUID:{p._uuid}") for p in qcirc.parameters}
-        qcirc = cast(QuantumCircuit, qcirc.assign_parameters(updates))
+        qcirc = cast("QuantumCircuit", qcirc.assign_parameters(updates))
 
     builder = CircuitBuilder(
         qregs=qcirc.qregs,
@@ -1182,12 +1182,14 @@ def get_avg_characterisation(
         k: f(v) for k, v in d.items()
     }
 
-    node_errors = cast(dict[Node, dict[OpType, float]], characterisation["NodeErrors"])
+    node_errors = cast(
+        "dict[Node, dict[OpType, float]]", characterisation["NodeErrors"]
+    )
     link_errors = cast(
-        dict[tuple[Node, Node], dict[OpType, float]], characterisation["EdgeErrors"]
+        "dict[tuple[Node, Node], dict[OpType, float]]", characterisation["EdgeErrors"]
     )
     readout_errors = cast(
-        dict[Node, list[list[float]]], characterisation["ReadoutErrors"]
+        "dict[Node, list[list[float]]]", characterisation["ReadoutErrors"]
     )
 
     avg: Callable[[dict[Any, float]], float] = lambda xs: sum(  # noqa: E731

--- a/pytket/extensions/qiskit/qiskit_convert.py
+++ b/pytket/extensions/qiskit/qiskit_convert.py
@@ -32,7 +32,7 @@ import numpy as np
 import sympy
 from numpy.typing import NDArray
 from qiskit_ibm_runtime.models.backend_configuration import (  # type: ignore
-    PulseBackendConfiguration,
+    QasmBackendConfiguration,
 )
 from qiskit_ibm_runtime.models.backend_properties import (  # type: ignore
     BackendProperties,
@@ -217,7 +217,7 @@ _gate_str_2_optype_rev = {v: k for k, v in _gate_str_2_optype.items()}
 _gate_str_2_optype_rev[OpType.Unitary1qBox] = "unitary"
 
 
-def _tk_gate_set(config: PulseBackendConfiguration) -> set[OpType]:
+def _tk_gate_set(config: QasmBackendConfiguration) -> set[OpType]:
     """Set of tket gate types supported by the qiskit backend"""
     if config.simulator:
         gate_set = {
@@ -1067,7 +1067,7 @@ def process_characterisation(backend: "IBMBackend") -> dict[str, Any]:
 
 
 def process_characterisation_from_config(
-    config: PulseBackendConfiguration, properties: Optional[BackendProperties]
+    config: QasmBackendConfiguration, properties: Optional[BackendProperties]
 ) -> dict[str, Any]:
     """Obtain a dictionary containing device Characteristics given config and props.
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     install_requires=[
         "pytket >= 2.0.1",
         "qiskit >= 1.3.1, < 2",
-        "qiskit-ibm-runtime >= 0.30.0",
+        "qiskit-ibm-runtime >= 0.37.0",
         "qiskit-aer >= 0.15.1",
         "numpy >= 1.26.4",
     ],

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -324,8 +324,8 @@ def test_process_characterisation_complete_noise_model() -> None:
     back = AerBackend(my_noise_model)
     char = back.backend_info.get_misc("characterisation")
 
-    node_errors = cast(dict, back.backend_info.all_node_gate_errors)
-    link_errors = cast(dict, back.backend_info.all_edge_gate_errors)
+    node_errors = cast("dict", back.backend_info.all_node_gate_errors)
+    link_errors = cast("dict", back.backend_info.all_edge_gate_errors)
     arch = back.backend_info.architecture
     assert node_errors is not None
     assert link_errors is not None
@@ -347,7 +347,7 @@ def test_process_characterisation_complete_noise_model() -> None:
     assert (
         round(link_errors[(arch.nodes[1], arch.nodes[0])][OpType.CX], 8) == 0.80859375
     )
-    readout_errors = cast(dict, back.backend_info.all_readout_errors)
+    readout_errors = cast("dict", back.backend_info.all_readout_errors)
     assert readout_errors[arch.nodes[0]] == [
         [0.8, 0.2],
         [0.2, 0.8],
@@ -382,9 +382,9 @@ def test_process_model() -> None:
     assert "characterisation" in b.backend_info.misc
     assert "GenericOneQubitQErrors" in b.backend_info.misc["characterisation"]
     assert "GenericTwoQubitQErrors" in b.backend_info.misc["characterisation"]
-    node_gate_errors = cast(dict, b.backend_info.all_node_gate_errors)
+    node_gate_errors = cast("dict", b.backend_info.all_node_gate_errors)
     assert nodes[3] in node_gate_errors
-    edge_gate_errors = cast(dict, b.backend_info.all_edge_gate_errors)
+    edge_gate_errors = cast("dict", b.backend_info.all_edge_gate_errors)
     assert (nodes[7], nodes[8]) in edge_gate_errors
 
 
@@ -419,7 +419,7 @@ def test_machine_debug(brisbane_backend: IBMQBackend) -> None:
         from pytket.extensions.qiskit.backends.ibm import _DEBUG_HANDLE_PREFIX
 
         assert all(
-            cast(str, hand[0]).startswith(_DEBUG_HANDLE_PREFIX) for hand in handles
+            cast("str", hand[0]).startswith(_DEBUG_HANDLE_PREFIX) for hand in handles
         )
 
         correct_counts = {(0, 0): 4}
@@ -452,7 +452,7 @@ def test_nshots_batching(brisbane_backend: IBMQBackend) -> None:
         from pytket.extensions.qiskit.backends.ibm import _DEBUG_HANDLE_PREFIX
 
         assert all(
-            cast(str, hand[0]) == _DEBUG_HANDLE_PREFIX + suffix
+            cast("str", hand[0]) == _DEBUG_HANDLE_PREFIX + suffix
             for hand, suffix in zip(
                 handles,
                 [f"{(10, 0)}", f"{(12, 1)}", f"{(10, 0)}", f"{(13, 2)}"],
@@ -1011,7 +1011,7 @@ def test_compilation_correctness(brisbane_backend: IBMQBackend) -> None:
     c.remove_blank_wires()
     FlattenRelabelRegistersPass().apply(c)
     c_pred = ConnectivityPredicate(
-        cast(Architecture, brisbane_backend.backend_info.architecture)
+        cast("Architecture", brisbane_backend.backend_info.architecture)
     )
     for ol in range(3):
         p = brisbane_backend.default_compilation_pass(optimisation_level=ol)
@@ -1077,7 +1077,7 @@ def test_postprocess() -> None:
     c.X(0).X(1).measure_all()
     c = b.get_compiled_circuit(c)
     h = b.process_circuit(c, n_shots=10, postprocess=True)
-    ppcirc = Circuit.from_dict(json.loads(cast(str, h[3])))
+    ppcirc = Circuit.from_dict(json.loads(cast("str", h[3])))
     ppcmds = ppcirc.get_commands()
     assert len(ppcmds) > 0
     assert all(ppcmd.op.type == OpType.ClassicalTransform for ppcmd in ppcmds)
@@ -1092,7 +1092,7 @@ def test_postprocess_emu(brisbane_emulator_backend: IBMQEmulatorBackend) -> None
     c.X(0).X(1).measure_all()
     c = brisbane_emulator_backend.get_compiled_circuit(c)
     h = brisbane_emulator_backend.process_circuit(c, n_shots=10, postprocess=True)
-    ppcirc = Circuit.from_dict(json.loads(cast(str, h[3])))
+    ppcirc = Circuit.from_dict(json.loads(cast("str", h[3])))
     ppcmds = ppcirc.get_commands()
     assert len(ppcmds) > 0
     assert all(ppcmd.op.type == OpType.ClassicalTransform for ppcmd in ppcmds)

--- a/tests/mock_pytket_backend.py
+++ b/tests/mock_pytket_backend.py
@@ -95,7 +95,7 @@ class MockShotBackend(Backend):
 
     def get_result(self, handle: ResultHandle, **kwargs: KwargTypes) -> BackendResult:
         """Always return a single readout containing all 1s."""
-        circ_rep = json.loads(cast(str, handle[1]))
+        circ_rep = json.loads(cast("str", handle[1]))
         circ = Circuit.from_dict(circ_rep)
         shots_list = [[1] * circ.n_bits]
         outcome_arr = OutcomeArray.from_readouts(shots_list)


### PR DESCRIPTION
# Description

`PulseBackendConfiguration` has been [removed](https://github.com/Qiskit/qiskit-ibm-runtime/pull/2180) in qiskit runtime 0.37.0, all backends now return `QasmBackendConfiguration`. This PR also includes the necessary changes to comply with the new ruff rules.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
