### PR TITLE
fix: update changelog heading

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,7 +4,7 @@
 
 # Changelog
 
-# 0.66.0 (March 2025)
+## 0.66.0 (March 2025)
 
 - Update qiskit minimum version requirement to 1.4.2.
 - Uptdate lightsabre pass to be a `CustomPassMap` object.


### PR DESCRIPTION
# Description

Just fixing the markdown heading

This is how it looks in the deployed docs before this change.

![Screenshot 2025-03-27 at 14 37 45](https://github.com/user-attachments/assets/62bef008-2e96-4963-b6d5-6e6053b274a5)
![Screenshot 2025-03-27 at 14 37 50](https://github.com/user-attachments/assets/848138ab-32c5-4908-8a94-de763019ed9a)
