### PR TITLE
Don't introduce implicit swaps when transpiling for unitary and density-matrix backends

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,12 +4,11 @@
 
 # Changelog
 
-Unreleased
-----------
+## Unreleased
 
-Features:
-
-* Add `VF2PostLayout` to default compilation.
+- Add `VF2PostLayout` to default compilation.
+- Fix: don't introduce implicit swaps when transpiling for unitary and density-
+  matrix backends.
 
 ## 0.67.0 (April 2025)
 

--- a/pytket/extensions/qiskit/backends/aer.py
+++ b/pytket/extensions/qiskit/backends/aer.py
@@ -443,7 +443,7 @@ class _AerBaseBackend(Backend):
                 ppcirc_strs.append(json.dumps(ppcirc_rep))
 
             if self._needs_transpile:
-                qcs = transpile(qcs, self._qiskit_backend)
+                qcs = transpile(qcs, self._qiskit_backend, optimization_level=1)
 
             job = self._qiskit_backend.run(
                 qcs,

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -1588,3 +1588,23 @@ def test_noise_model_relabelling() -> None:
 
     assert cu.initial_map == {qubit: Node(3)}
     assert cu.final_map == {qubit: Node(3)}
+
+
+def test_swap_unitary_compilation() -> None:
+    # https://github.com/CQCL/pytket-qiskit/issues/485
+    c = Circuit(2)
+    c.SWAP(0, 1)
+    b = AerUnitaryBackend()
+    h = b.process_circuit(c)
+    result = b.get_result(h)
+    u = result.get_unitary()
+    u_swap = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ],
+        dtype=complex,
+    )
+    assert np.allclose(u, u_swap)


### PR DESCRIPTION
Fixes #485 .