### PR TITLE
Don't run remote checks in release workflow.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,12 +48,17 @@ jobs:
       with:
         python-version: '3.11'
     - name: Build and test including remote checks (3.11) mypy
-      if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
+      if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'schedule' )
       shell: bash
       run: |
         ./.github/workflows/build-test mypy
       env:
         PYTKET_RUN_REMOTE_TESTS: 1
+    - name: Build and test (3.11) mypy
+      if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'release')
+      shell: bash
+      run: |
+        ./.github/workflows/build-test mypy
     - name: Build and test (3.11) nomypy
       if:  (matrix.os != 'macos-latest') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
       shell: bash


### PR DESCRIPTION
They can fail because of timeouts and network issues which we don't want to block a release. They should already have been run in PRs for every change anyway.