### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ tags: [skip-execution]
 # Replace the placeholders with your actual values
 
 ibm_token = '<your_ibm_token_here>'
-inst = '<your_instance_CRN_here>''
+inst = '<your_instance_CRN_here>'
 ```
 
 The instance CRN is the long string beginning with "crn:" which is shown on the

--- a/pytket/extensions/qiskit/backends/config.py
+++ b/pytket/extensions/qiskit/backends/config.py
@@ -2,7 +2,7 @@
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
-# You may obtain a copy of the License atF
+# You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #

--- a/pytket/extensions/qiskit/backends/crosstalk_model.py
+++ b/pytket/extensions/qiskit/backends/crosstalk_model.py
@@ -91,7 +91,7 @@ class CrosstalkParams:
     :param gate_times: python dict to store the gate time information.
     :param phase_damping_error: dict specify amplitude phase damping error
         on each qubit
-    :param amplitude_damping_error: dict pecify amplitude damping error
+    :param amplitude_damping_error: dict specify amplitude damping error
         on each qubit
     """
 

--- a/pytket/extensions/qiskit/backends/ibm.py
+++ b/pytket/extensions/qiskit/backends/ibm.py
@@ -354,7 +354,7 @@ class IBMQBackend(Backend):
         timeout: int = 300,
     ) -> BasePass:
         """
-        A suggested compilation pass that will will, if possible, produce an equivalent
+        A suggested compilation pass that will, if possible, produce an equivalent
         circuit suitable for running on this backend.
 
         At a minimum it will ensure that compatible gates are used and that all two-
@@ -370,7 +370,7 @@ class IBMQBackend(Backend):
             compilation.
         :param timeout: Parameter for optimisation level 3, given in seconds.
 
-            - Level 0 does the minimum required to solves the device constraints,
+            - Level 0 does the minimum required to solve the device constraints,
               without any optimisation.
             - Level 1 additionally performs some light optimisations.
             - Level 2 (the default) adds more computationally intensive optimisations

--- a/pytket/extensions/qiskit/backends/ibmq_emulator.py
+++ b/pytket/extensions/qiskit/backends/ibmq_emulator.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 
 class IBMQEmulatorBackend(Backend):
-    """A backend which uses the AerBackend to loaclly emulate the behaviour of
+    """A backend which uses the AerBackend to locally emulate the behaviour of
     :py:class:`~.IBMQBackend`. Identical to :py:class:`~.IBMQBackend` except there is no ``monitor``
     parameter. Performs the same compilation and predicate checks as :py:class:`~.IBMQBackend`.
     Requires a valid IBM account.


### PR DESCRIPTION
# Description
**Fix typos and syntax**
- Remove extra quote
- atF -> at
- pecify -> specify
- solves -> solve
- loaclly -> locally
- Remove duplicate word "will"
